### PR TITLE
Cleanup code and migrate data to yml file

### DIFF
--- a/cogs/timings.py
+++ b/cogs/timings.py
@@ -185,14 +185,14 @@ class Timings(commands.Cog):
             try:
                 plugins = r["timingsMaster"]["plugins"]
                 if not YAML_ERROR:
-                    for plugin in plugins:
-                        for stored_plugin in TIMINGS_CHECK["plugins"]["paper"]:
-                            if plugin == stored_plugin["name"]:
-                                embed_var.add_field(**create_field(stored_plugin))
-                        if "purpur" in r["timingsMaster"]["config"] and "purpur" in TIMINGS_CHECK["plugins"]:
-                            for stored_plugin in TIMINGS_CHECK["plugins"]["purpur"]:
-                                if plugin == stored_plugin["name"]:
-                                    embed_var.add_field(**create_field(stored_plugin))
+                    for server_name in TIMINGS_CHECK["plugins"]:
+                        if server_name in r["timingsMaster"]["config"]:
+                            for plugin in plugins:
+                                for plugin_name in TIMINGS_CHECK["plugins"][server_name]:
+                                    if plugin == plugin_name:
+                                        stored_plugin = TIMINGS_CHECK["plugins"][server_name][plugin_name]
+                                        stored_plugin["name"] = plugin_name
+                                        embed_var.add_field(**create_field(stored_plugin))
                 else:
                     embed_var.add_field(name="Error loading YAML file",
                                         value=YAML_ERROR)

--- a/cogs/timings.py
+++ b/cogs/timings.py
@@ -77,14 +77,32 @@ class Timings(commands.Cog):
                 unchecked = unchecked + 1
 
             try:
-                online_mode = r["timingsMaster"]["onlinemode"]
-                bungeecord = r["timingsMaster"]["config"]["spigot"]["settings"]["bungeecord"]
-                velocity_online_mode = r["timingsMaster"]["config"]["paper"]["settings"]["velocity-support"]["online-mode"]
-                velocity_enabled = r["timingsMaster"]["config"]["paper"]["settings"]["velocity-support"]["enabled"]
+                if "config" in TIMINGS_CHECK:
+                    server_properties = None
+                    bukkit = None
+                    spigot = None
+                    paper = None
+                    purpur = None
+                    if "server.properties" in r["timingsMaster"]["config"]:
+                        server_properties = r["timingsMaster"]["config"]["server.properties"]
+                    if "bukkit" in r["timingsMaster"]["config"]:
+                        bukkit = r["timingsMaster"]["config"]["bukkit"]
+                    if "spigot" in r["timingsMaster"]["config"]:
+                        spigot = r["timingsMaster"]["config"]["spigot"]
+                    if "paper" in r["timingsMaster"]["config"]:
+                        paper = r["timingsMaster"]["config"]["paper"]
+                    if "purpur" in r["timingsMaster"]["config"]:
+                        purpur = r["timingsMaster"]["config"]["purpur"]
 
-                if not online_mode and bungeecord == "false" and (velocity_online_mode == "false" or velocity_enabled == "false"):
-                    embed_var.add_field(name="❌ online-mode",
-                                        value="Enable this in server.properties for security.")
+                    for config_name in TIMINGS_CHECK["config"]:
+                        config = TIMINGS_CHECK["config"][config_name]
+                        for option_name in config:
+                            option = config[option_name]
+                            for expression in option["expressions"]:
+                                if not eval(expression):
+                                    continue
+                                embed_var.add_field(**create_field({**{"name": option_name}, **option}))
+
             except KeyError:
                 unchecked = unchecked + 1
 
@@ -223,72 +241,6 @@ class Timings(commands.Cog):
                 unchecked = unchecked + 1
 
             try:
-                spigot_view_distance = r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["view-distance"]
-                view_distance = int(r["timingsMaster"]["config"]["server.properties"]["view-distance"])
-                if view_distance >= 10 and spigot_view_distance == "default":
-                    embed_var.add_field(name="❌ view-distance",
-                                        value="Decrease this from default (10) in spigot.yml. "
-                                              "Recommended: 3.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                chunk_gc_period = int(r["timingsMaster"]["config"]["bukkit"]["chunk-gc"]["period-in-ticks"])
-                if chunk_gc_period >= 600:
-                    embed_var.add_field(name="❌ chunk-gc.period-in-ticks",
-                                        value="Decrease this in bukkit.yml.\nRecommended: 400.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                ticks_per_monster_spawns = int(r["timingsMaster"]["config"]["bukkit"]["ticks-per"]["monster-spawns"])
-                if ticks_per_monster_spawns == 1:
-                    embed_var.add_field(name="❌ ticks-per.monster-spawns",
-                                        value="Increase this in bukkit.yml.\nRecommended: 4.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                monsters_spawn_limit = int(r["timingsMaster"]["config"]["bukkit"]["spawn-limits"]["monsters"])
-                if monsters_spawn_limit >= 70:
-                    embed_var.add_field(name="❌ spawn-limits.monsters",
-                                        value="Decrease this in bukkit.yml.\nRecommended: 15.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                water_ambient_spawn_limit = int(r["timingsMaster"]["config"]["bukkit"]["spawn-limits"]["water-ambient"])
-                if water_ambient_spawn_limit >= 20:
-                    embed_var.add_field(name="❌ spawn-limits.water-ambient",
-                                        value="Decrease this in bukkit.yml.\nRecommended: 2.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                ambient_spawn_limit = int(r["timingsMaster"]["config"]["bukkit"]["spawn-limits"]["ambient"])
-                if ambient_spawn_limit >= 15:
-                    embed_var.add_field(name="❌ spawn-limits.ambient",
-                                        value="Decrease this in bukkit.yml.\nRecommended: 1.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                animals_spawn_limit = int(r["timingsMaster"]["config"]["bukkit"]["spawn-limits"]["animals"])
-                if animals_spawn_limit >= 10:
-                    embed_var.add_field(name="❌ spawn-limits.animals",
-                                        value="Decrease this in bukkit.yml.\nRecommended: 3.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                water_animals_spawn_limit = int(r["timingsMaster"]["config"]["bukkit"]["spawn-limits"]["water-animals"])
-                if water_animals_spawn_limit >= 15:
-                    embed_var.add_field(name="❌ spawn-limits.water-animals",
-                                        value="Decrease this in bukkit.yml.\nRecommended: 2.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
                 mob_spawn_range = int(r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["mob-spawn-range"])
                 spigot_view_distance = r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["view-distance"]
                 if spigot_view_distance == "default":
@@ -305,62 +257,9 @@ class Timings(commands.Cog):
                 unchecked = unchecked + 1
 
             try:
-                animals_entity_activation_range = int(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"][
-                        "animals"])
-                if animals_entity_activation_range >= 32:
-                    embed_var.add_field(name="❌ entity-activation-range.animals",
-                                        value="Decrease this in spigot.yml. "
-                                              "Recommended: 6.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                monsters_entity_activation_range = int(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"][
-                        "monsters"])
-                if monsters_entity_activation_range >= 32:
-                    embed_var.add_field(name="❌ entity-activation-range.monsters",
-                                        value="Decrease this in spigot.yml. "
-                                              "Recommended: 16.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
                 raiders_entity_activation_range = int(
                     r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"][
                         "raiders"])
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                misc_entity_activation_range = int(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"]["misc"])
-                if misc_entity_activation_range >= 16:
-                    embed_var.add_field(name="❌ entity-activation-range.misc",
-                                        value="Decrease this in spigot.yml. "
-                                              "Recommended: 4.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                water_entity_activation_range = int(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"]["water"])
-                if water_entity_activation_range >= 16:
-                    embed_var.add_field(name="❌ entity-activation-range.water",
-                                        value="Decrease this in spigot.yml. "
-                                              "Recommended: 12.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                villagers_entity_activation_range = int(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"][
-                        "villagers"])
-                if villagers_entity_activation_range >= 32:
-                    embed_var.add_field(name="❌ entity-activation-range.villagers",
-                                        value="Decrease this in spigot.yml. "
-                                              "Recommended: 16.")
             except KeyError:
                 unchecked = unchecked + 1
 
@@ -372,50 +271,12 @@ class Timings(commands.Cog):
                 unchecked = unchecked + 1
 
             try:
-                tick_inactive_villagers = \
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"][
-                        "tick-inactive-villagers"]
-                if tick_inactive_villagers == "true":
-                    embed_var.add_field(name="❌ tick-inactive-villagers",
-                                        value="Disable this in spigot.yml.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                nerf_spawner_mobs = r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["nerf-spawner-mobs"]
-                if nerf_spawner_mobs == "false":
-                    embed_var.add_field(name="❌ nerf-spawner-mobs",
-                                        value="Enable this in spigot.yml.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
                 wake_up_inactive_villagers_every = int(
                     r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"][
                         "wake-up-inactive"]["villagers-every"])
             except KeyError:
                 unchecked = unchecked + 1
-            try:
-                wake_up_inactive_villagers_for = int(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"][
-                        "wake-up-inactive"]["villagers-for"])
-                if wake_up_inactive_villagers_for >= 100:
-                    embed_var.add_field(name="❌ wake-up-inactive.villagers-for",
-                                        value="Decrease this in spigot.yml. "
-                                              "Recommended: 20.")
-            except KeyError:
-                unchecked = unchecked + 1
 
-            try:
-                wake_up_inactive_flying_monsters_for = int(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"][
-                        "wake-up-inactive"]["flying-monsters-for"])
-                if wake_up_inactive_flying_monsters_for >= 100:
-                    embed_var.add_field(name="❌ wake-up-inactive.flying-monsters-for",
-                                        value="Decrease this in spigot.yml. "
-                                              "Recommended: 60.")
-            except KeyError:
-                unchecked = unchecked + 1
 
             try:
                 wake_up_inactive_animals_every = int(
@@ -425,49 +286,7 @@ class Timings(commands.Cog):
             except KeyError:
                 unchecked = unchecked + 1
 
-            try:
-                wake_up_inactive_villagers_max_per_tick = int(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"][
-                        "wake-up-inactive"]["villagers-max-per-tick"])
-                if wake_up_inactive_villagers_max_per_tick >= 4:
-                    embed_var.add_field(name="❌ wake-up-inactive.villagers-max-per-tick",
-                                        value="Decrease this in spigot.yml. "
-                                              "Recommended: 1.")
-            except KeyError:
-                unchecked = unchecked + 1
 
-            try:
-                wake_up_inactive_animals_for = int(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"][
-                        "wake-up-inactive"]["animals-for"])
-                if wake_up_inactive_animals_for >= 100:
-                    embed_var.add_field(name="❌ wake-up-inactive.animals-for",
-                                        value="Decrease this in spigot.yml. "
-                                              "Recommended: 40.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                wake_up_inactive_monsters_max_per_tick = int(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"][
-                        "wake-up-inactive"]["monsters-max-per-tick"])
-                if wake_up_inactive_monsters_max_per_tick >= 8:
-                    embed_var.add_field(name="❌ wake-up-inactive.monsters-max-per-tick",
-                                        value="Decrease this in spigot.yml. "
-                                              "Recommended: 4.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                wake_up_inactive_flying_monsters_max_per_tick = int(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"][
-                        "wake-up-inactive"]["flying-monsters-max-per-tick"])
-                if wake_up_inactive_flying_monsters_max_per_tick >= 8:
-                    embed_var.add_field(name="❌ wake-up-inactive.flying-monsters-max-per-tick",
-                                        value="Decrease this in spigot.yml. "
-                                              "Recommended: 1.")
-            except KeyError:
-                unchecked = unchecked + 1
 
             try:
                 wake_up_inactive_flying_monsters_every = int(
@@ -480,236 +299,6 @@ class Timings(commands.Cog):
                 wake_up_inactive_monsters_every = int(
                     r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"][
                         "wake-up-inactive"]["monsters-every"])
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                wake_up_inactive_animals_max_per_tick = int(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"][
-                        "wake-up-inactive"]["animals-max-per-tick"])
-                if wake_up_inactive_animals_max_per_tick >= 4:
-                    embed_var.add_field(name="❌ wake-up-inactive.animals-max-per-tick",
-                                        value="Decrease this in spigot.yml. "
-                                              "Recommended: 2.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                wake_up_inactive_monsters_for = int(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"][
-                        "wake-up-inactive"]["monsters-for"])
-                if wake_up_inactive_monsters_for >= 100:
-                    embed_var.add_field(name="❌ wake-up-inactive.monsters-for",
-                                        value="Decrease this in spigot.yml. "
-                                              "Recommended: 60.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                arrow_despawn_rate = int(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["arrow-despawn-rate"])
-                if arrow_despawn_rate >= 1200:
-                    embed_var.add_field(name="❌ arrow-despawn-rate",
-                                        value="Decrease this in spigot.yml. "
-                                              "Recommended: 300.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                item_merge_radius = float(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["merge-radius"]["item"])
-                if item_merge_radius <= 2.5:
-                    embed_var.add_field(name="❌ merge-radius.item",
-                                        value="Increase this in spigot.yml. "
-                                              "Recommended: 4.0.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                exp_merge_radius = float(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["merge-radius"]["exp"])
-                if exp_merge_radius <= 3.0:
-                    embed_var.add_field(name="❌ merge-radius.exp",
-                                        value="Increase this in spigot.yml. "
-                                              "Recommended: 6.0.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                max_entity_collisions = int(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["max-entity-collisions"])
-                if max_entity_collisions >= 8:
-                    embed_var.add_field(name="❌ max-entity-collisions",
-                                        value="Decrease this in spigot.yml. "
-                                              "Recommended: 2.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                max_auto_save_chunks_per_tick = int(
-                    r["timingsMaster"]["config"]["paper"]["world-settings"]["default"]["max-auto-save-chunks-per-tick"])
-                if max_auto_save_chunks_per_tick >= 24:
-                    embed_var.add_field(name="❌ max-auto-save-chunks-per-tick",
-                                        value="Decrease this in paper.yml. "
-                                              "Recommended: 6.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                optimize_explosions = r["timingsMaster"]["config"]["paper"]["world-settings"]["default"][
-                    "optimize-explosions"]
-                if optimize_explosions == "false":
-                    embed_var.add_field(name="❌ optimize-explosions",
-                                        value="Enable this in paper.yml.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                mob_spawner_tick_rate = int(
-                    r["timingsMaster"]["config"]["paper"]["world-settings"]["default"]["mob-spawner-tick-rate"])
-                if mob_spawner_tick_rate == 1:
-                    embed_var.add_field(name="❌ mob-spawner-tick-rate",
-                                        value="Increase this in paper.yml. "
-                                              "Recommended: 2.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                disable_chest_cat_detection = \
-                    r["timingsMaster"]["config"]["paper"]["world-settings"]["default"]["game-mechanics"][
-                        "disable-chest-cat-detection"]
-                if disable_chest_cat_detection == "false":
-                    embed_var.add_field(name="❌ disable-chest-cat-detection",
-                                        value="Enable this in paper.yml.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                container_update_tick_rate = int(
-                    r["timingsMaster"]["config"]["paper"]["world-settings"]["default"]["container-update-tick-rate"])
-                if container_update_tick_rate == "false":
-                    embed_var.add_field(name="❌ container-update-tick-rate",
-                                        value="Increase this in paper.yml. "
-                                              "Recommended: 3.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                grass_spread_tick_rate = int(
-                    r["timingsMaster"]["config"]["paper"]["world-settings"]["default"]["grass-spread-tick-rate"])
-                if grass_spread_tick_rate == 1:
-                    embed_var.add_field(name="❌ grass-spread-tick-rate",
-                                        value="Increase this in paper.yml. "
-                                              "Recommended: 4")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                soft_despawn_range = int(
-                    r["timingsMaster"]["config"]["paper"]["world-settings"]["default"]["despawn-ranges"]["soft"])
-                if soft_despawn_range >= 32:
-                    embed_var.add_field(name="❌ despawn-ranges.soft",
-                                        value="Decrease this in paper.yml. "
-                                              "Recommended: 28")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                hard_despawn_range = int(r["timingsMaster"]["config"]["paper"]["world-settings"]["default"]["despawn-ranges"]["soft"])
-                if hard_despawn_range >= 128:
-                    embed_var.add_field(name="❌ despawn-ranges.hard",
-                                        value="Decrease this in paper.yml. "
-                                              "Recommended: 48")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                hopper_disable_move_event = r["timingsMaster"]["config"]["paper"]["world-settings"]["default"]["hopper"][
-                    "disable-move-event"]
-                if hopper_disable_move_event == "false":
-                    embed_var.add_field(name="❌ hopper.disable-move-event",
-                                        value="Enable this in paper.yml.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                non_player_arrow_despawn_rate = int(
-                    r["timingsMaster"]["config"]["paper"]["world-settings"]["default"]["non-player-arrow-despawn-rate"])
-                if non_player_arrow_despawn_rate == -1:
-                    embed_var.add_field(name="❌ non-player-arrow-despawn-rate",
-                                        value="Set a value in paper.yml. "
-                                              "Recommended: 60")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                creative_arrow_despawn_rate = int(
-                    r["timingsMaster"]["config"]["paper"]["world-settings"]["default"]["creative-arrow-despawn-rate"])
-                if creative_arrow_despawn_rate == -1:
-                    embed_var.add_field(name="❌ creative-arrow-despawn-rate",
-                                        value="Set a value in paper.yml. "
-                                              "Recommended: 60")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                prevent_moving_into_unloaded_chunks = r["timingsMaster"]["config"]["paper"]["world-settings"]["default"][
-                    "prevent-moving-into-unloaded-chunks"]
-                if prevent_moving_into_unloaded_chunks == "false":
-                    embed_var.add_field(name="❌ prevent-moving-into-unloaded-chunks",
-                                        value="Enable this in paper.yml.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                eigencraft_redstone = r["timingsMaster"]["config"]["paper"]["world-settings"]["default"][
-                    "use-faster-eigencraft-redstone"]
-                if eigencraft_redstone == "false":
-                    embed_var.add_field(name="❌ use-faster-eigencraft-redstone",
-                                        value="Enable this in paper.yml.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                fix_climbing_bypass_gamerule = r["timingsMaster"]["config"]["paper"]["world-settings"]["default"]["fix-climbing-bypassing-cramming-rule"]
-                if fix_climbing_bypass_gamerule == "false":
-                    embed_var.add_field(name="❌ fix-climbing-bypassing-cramming-rule",
-                                        value="Enable this in paper.yml.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                armor_stands_do_collision_entity_lookups = r["timingsMaster"]["config"]["paper"]["world-settings"]["default"]["armor-stands-do-collision-entity-lookups"]
-                if armor_stands_do_collision_entity_lookups == "true":
-                    embed_var.add_field(name="❌ armor-stands-do-collision-entity-lookups",
-                                        value="Disable this in paper.yml.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                plugins = r["timingsMaster"]["plugins"]
-                armor_stands_tick = r["timingsMaster"]["config"]["paper"]["world-settings"]["default"]["armor-stands-tick"]
-                if armor_stands_tick == "true" and "PetBlocks" not in plugins and "BlockBalls" not in plugins and "ArmorStandTools" not in plugins:
-                    embed_var.add_field(name="❌ armor-stands-tick",
-                                        value="Disable this in paper.yml.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                per_player_mob_spawns = r["timingsMaster"]["config"]["paper"]["world-settings"]["default"][
-                    "per-player-mob-spawns"]
-                if per_player_mob_spawns == "false":
-                    embed_var.add_field(name="❌ per-player-mob-spawns",
-                                        value="Enable this in paper.yml.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                alt_item_despawn_rate_enabled = \
-                    r["timingsMaster"]["config"]["paper"]["world-settings"]["default"]["alt-item-despawn-rate"]["enabled"]
-                if alt_item_despawn_rate_enabled == "false":
-                    embed_var.add_field(name="❌ alt-item-despawn-rate.enabled",
-                                        value="Enable this in paper.yml.")
             except KeyError:
                 unchecked = unchecked + 1
 
@@ -734,24 +323,6 @@ class Timings(commands.Cog):
                 unchecked = unchecked + 1
 
             try:
-                enable_treasure_maps = r["timingsMaster"]["config"]["paper"]["world-settings"]["default"][
-                    "enable-treasure-maps"]
-                if enable_treasure_maps == "true":
-                    embed_var.add_field(name="❌ enable-treasure-maps",
-                                        value="Disable this in paper.yml. Why? Generating treasure maps is extremely expensive and can hang a server if the structure it's trying to locate is really far away.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                projectile_load_save = int(r["timingsMaster"]["config"]["paper"]["world-settings"]["default"][
-                                               "projectile-load-save-per-chunk-limit"])
-                if projectile_load_save == -1:
-                    embed_var.add_field(name="❌ projectile-load-save-per-chunk-limit",
-                                        value="Set a value in paper.yml. Recommended: 8.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
                 use_alternate_keepalive = r["timingsMaster"]["config"]["purpur"]["settings"]["use-alternate-keepalive"]
                 plugins = r["timingsMaster"]["plugins"]
                 if use_alternate_keepalive == "false" and "TCPShield" not in plugins:
@@ -763,94 +334,6 @@ class Timings(commands.Cog):
             except KeyError:
                 unchecked = unchecked + 1
 
-            try:
-                dont_send_useless_entity_packets = r["timingsMaster"]["config"]["purpur"]["settings"][
-                    "dont-send-useless-entity-packets"]
-                if dont_send_useless_entity_packets == "false":
-                    embed_var.add_field(name="❌ dont-send-useless-entity-packets",
-                                        value="Enable this in purpur.yml.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                disable_treasure_searching = \
-                    r["timingsMaster"]["config"]["purpur"]["world-settings"]["default"]["mobs"]["dolphin"][
-                        "disable-treasure-searching"]
-                if disable_treasure_searching == "false":
-                    embed_var.add_field(name="❌ dolphin.disable-treasure-searching",
-                                        value="Enable this in purpur.yml.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                brain_ticks = int(
-                    r["timingsMaster"]["config"]["purpur"]["world-settings"]["default"]["mobs"]["villager"][
-                        "brain-ticks"])
-                if brain_ticks == 1:
-                    embed_var.add_field(name="❌ villager.brain-ticks",
-                                        value="Increase this in purpur.yml. "
-                                              "Recommended: 4.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                iron_golem_radius = int(
-                    r["timingsMaster"]["config"]["purpur"]["world-settings"]["default"]["mobs"]["villager"][
-                        "spawn-iron-golem"]["radius"])
-                if iron_golem_radius == 0:
-                    embed_var.add_field(name="❌ spawn-iron-golem.radius",
-                                        value="Set a value in purpur.yml. "
-                                              "Recommended: 32.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                iron_golem_limit = int(
-                    r["timingsMaster"]["config"]["purpur"]["world-settings"]["default"]["mobs"]["villager"][
-                        "spawn-iron-golem"]["limit"])
-                if iron_golem_limit == 0:
-                    embed_var.add_field(name="❌ spawn-iron-golem.limit",
-                                        value="Set a value in purpur.yml. "
-                                              "Recommended: 5.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                aggressive_towards_villager_when_lagging = \
-                    r["timingsMaster"]["config"]["purpur"]["world-settings"]["default"]["mobs"]["zombie"][
-                        "aggressive-towards-villager-when-lagging"]
-                if aggressive_towards_villager_when_lagging == "true":
-                    embed_var.add_field(name="❌ zombie.aggresive-towards-villager-when-lagging",
-                                        value="Disable this in purpur.yml.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                entities_can_use_portals = \
-                    r["timingsMaster"]["config"]["purpur"]["world-settings"]["default"]["gameplay-mechanics"][
-                        "entities-can-use-portals"]
-                if entities_can_use_portals == "true":
-                    embed_var.add_field(name="❌ entities-can-use-portals",
-                                        value="Disable this in purpur.yml to prevent players from creating chunk anchors.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                lobotomize_enabled = r["timingsMaster"]["config"]["purpur"]["world-settings"]["default"]["mobs"]["villager"][
-                        "lobotomize"]["enabled"]
-                if lobotomize_enabled == "false":
-                    embed_var.add_field(name="❌ villager.lobotomize.enabled",
-                                        value="Enable this in purpur.yml.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                teleport_if_outside_border = r["timingsMaster"]["config"]["purpur"]["world-settings"]["default"]["gameplay-mechanics"]["player"]["teleport-if-outside-border"]
-                if teleport_if_outside_border == "false":
-                    embed_var.add_field(name="❌ player.teleport-if-outside-border",
-                                        value="Enable this in purpur.yml.")
-            except KeyError:
-                unchecked = unchecked + 1
         except ValueError:
             embed_var.add_field(name="❌ Invalid Configuration",
                                 value="At least one of your configuration files had an invalid data type.")

--- a/cogs/timings.py
+++ b/cogs/timings.py
@@ -63,19 +63,16 @@ class Timings(commands.Cog):
         unchecked = 0
         try:
             try:
-                version = r["timingsMaster"]["version"]
-                if "1.16.4" not in version:
-                    embed_var.add_field(name="❌ Legacy Build",
-                                        value="Update to 1.16.4.")
-                using_yatopia = "yatopia" in r["timingsMaster"]["config"]
-                if using_yatopia:
-                    embed_var.add_field(name="❌ Yatopia",
-                                        value="Yatopia is prone to bugs. "
-                                              "Consider using [Purpur](https://ci.pl3x.net/job/Purpur/).")
-                elif "Paper" in version:
-                    embed_var.add_field(name="||❌ Paper||",
-                                        value="||Purpur has more optimizations but is generally less supported. "
-                                              "Consider using [Purpur](https://ci.pl3x.net/job/Purpur/).||")
+                version = r["timingsMaster"]["version"].lower()
+                if "version" in TIMINGS_CHECK:
+                    if TIMINGS_CHECK["version"] in version:
+                        embed_var.add_field(name="❌ Legacy Build",
+                                            value="Update to " + TIMINGS_CHECK["server"]["version"])
+                if "servers" in TIMINGS_CHECK:
+                    for server in TIMINGS_CHECK["servers"]:
+                        if server["name"] in version:
+                            embed_var.add_field(**create_field(server))
+                            break
             except KeyError:
                 unchecked = unchecked + 1
 

--- a/cogs/timings.py
+++ b/cogs/timings.py
@@ -1,6 +1,16 @@
 import discord
 from discord.ext import commands
 import requests
+import yaml
+
+TIMINGS_CHECK = None
+YAML_ERROR = None
+with open("cogs/timings_check.yml", 'r') as stream:
+    try:
+        TIMINGS_CHECK = yaml.safe_load(stream)
+    except yaml.YAMLError as exc:
+        print(exc)
+        YAML_ERROR = exc
 
 class Timings(commands.Cog):
 
@@ -159,109 +169,18 @@ class Timings(commands.Cog):
 
             try:
                 plugins = r["timingsMaster"]["plugins"]
-                if "ClearLag" in plugins:
-                    embed_var.add_field(name="❌ ClearLag",
-                                        value="Plugins that claim to remove lag actually cause more lag. "
-                                              "Remove ClearLag.")
-                if "LagAssist" in plugins:
-                    embed_var.add_field(name="❌ LagAssist",
-                                        value="LagAssist should only be used for analytics and preventative measures."
-                                              "All other features of the plugin should be disabled.")
-                if "NoChunkLag" in plugins:
-                    embed_var.add_field(name="❌ NoChunkLag",
-                                        value="Plugins that claim to remove lag actually cause more lag. "
-                                              "Remove NoChunkLag.")
-                if "ServerBooster" in plugins:
-                    embed_var.add_field(name="❌ ServerBooster",
-                                        value="Plugins that claim to remove lag actually cause more lag. "
-                                              "Remove ServerBooster.")
-                if "MobLimiter" in plugins:
-                    embed_var.add_field(name="❌ MobLimiter",
-                                        value="You probably don't need MobLimiter as Bukkit already has its features. "
-                                              "Remove MobLimiter.")
-                if "BookLimiter" in plugins:
-                    embed_var.add_field(name="❌ BookLimiter",
-                                        value="You probably don't need BookLimiter as Paper already has its features. "
-                                              "Remove BookLimiter.")
-                if "LimitPillagers" in plugins:
-                    embed_var.add_field(name="❌ LimitPillagers",
-                                        value="You probably don't need LimitPillagers as Paper already adds its features. "
-                                              "Remove LimitPillagers.")
-                if "VillagerOptimiser" in plugins:
-                    embed_var.add_field(name="❌ VillagerOptimiser",
-                                        value="You probably don't need VillagerOptimiser as Paper already adds its features. "
-                                              "See entity-activation-range in spigot.yml.")
-                if "StackMob" in plugins:
-                    embed_var.add_field(name="❌ StackMob",
-                                        value="Stacking plugins actually cause more lag. "
-                                              "Remove StackMob.")
-                if "Stacker" in plugins:
-                    embed_var.add_field(name="❌ Stacker",
-                                        value="Stacking plugins actually cause more lag. "
-                                              "Remove Stacker.")
-                if "MobStacker" in plugins:
-                    embed_var.add_field(name="❌ MobStacker",
-                                        value="Stacking plugins actually cause more lag. "
-                                              "Remove MobStacker.")
-                if "WildStacker" in plugins:
-                    embed_var.add_field(name="❌ WildStacker",
-                                        value="Stacking plugins actually cause more lag. "
-                                              "Remove WildStacker.")
-                if "SuggestionBlocker" in plugins:
-                    embed_var.add_field(name="❌ SuggestionBlocker",
-                                        value="You probably don't need SuggestionBlocker as Spigot already adds its features. "
-                                              "Set tab-complete to -1 in spigot.yml.")
-                if "FastAsyncWorldEdit" in plugins:
-                    embed_var.add_field(name="❌ FastAsyncWorldEdit",
-                                        value="FAWE can corrupt your world. "
-                                              "Consider replacing FAWE with [Worldedit](https://enginehub.org/worldedit/#downloads).")
-                if "CMI" in plugins:
-                    embed_var.add_field(name="❌ CMI",
-                                        value="CMI is a buggy plugin. "
-                                              "Consider replacing CMI with [EssentialsX](https://essentialsx.net/downloads.html).")
-                if "Spartan" in plugins:
-                    embed_var.add_field(name="❌ Spartan",
-                                        value="Spartan is a laggy anticheat. "
-                                              "Consider replacing it with [Matrix](https://matrix.rip/), [NCP](https://ci.codemc.io/job/Updated-NoCheatPlus/job/Updated-NoCheatPlus/), or [AAC](https://www.spigotmc.org/resources/aac-advanced-anti-cheat-hack-kill-aura-blocker.6442/).")
-                if "IllegalStack" in plugins:
-                    embed_var.add_field(name="❌ IllegalStack",
-                                        value="You probably don't need IllegalStack as Paper already has its features. "
-                                              "Remove IllegalStack.")
-                if "ExploitFixer" in plugins:
-                    embed_var.add_field(name="❌ ExploitFixer",
-                                        value="You probably don't need ExploitFixer as Paper already has its features. "
-                                              "Remove ExploitFixer.")
-                if "EntityTrackerFixer" in plugins:
-                    embed_var.add_field(name="❌ EntityTrackerFixer",
-                                        value="You probably don't need EntityTrackerFixer as Paper already has its features. "
-                                              "Remove EntityTrackerFixer.")
-                if "Orebfuscator" in plugins:
-                    embed_var.add_field(name="❌ Orebfuscator",
-                                        value="You probably don't need Orebfuscator as Paper already has its features. "
-                                              "Remove Orebfuscator.")
-                if "ImageOnMap" in plugins:
-                    embed_var.add_field(name="❌ ImageOnMap",
-                                        value="This plugin has a [memory leak](https://github.com/zDevelopers/ImageOnMap/issues/104). If it is not essential, you should remove it. "
-                                              "Consider replacing it with [an alternative](https://www.spigotmc.org/resources/drmap.87368/).")
-                if "CrazyActions" in plugins:
-                    embed_var.add_field(name="❌ CrazyAuctions",
-                                        value="CrazyAuctions is a laggy plugin, even according to the developer. "
-                                              "Consider replacing it with [AuctionHouse](https://www.spigotmc.org/resources/auctionhouse.61836/).")
-                if "GroupManager" in plugins:
-                    embed_var.add_field(name="❌ GroupManager",
-                                        value="GroupManager is an outdated permission plugin. "
-                                              "Consider replacing it with [LuckPerms](https://ci.lucko.me/job/LuckPerms/1243/artifact/bukkit/build/libs/LuckPerms-Bukkit-5.2.77.jar).")
-                if "PermissionsEx" in plugins:
-                    embed_var.add_field(name="❌ PermissionsEx",
-                                        value="PermissionsEx is an outdated permission plugin. "
-                                              "Consider replacing it with [LuckPerms](https://ci.lucko.me/job/LuckPerms/1243/artifact/bukkit/build/libs/LuckPerms-Bukkit-5.2.77.jar).")
-                if "bPermissions" in plugins:
-                    embed_var.add_field(name="❌ bPermissions",
-                                        value="bPermissions is an outdated permission plugin. "
-                                              "Consider replacing it with [LuckPerms](https://ci.lucko.me/job/LuckPerms/1243/artifact/bukkit/build/libs/LuckPerms-Bukkit-5.2.77.jar).")
-                if "DisableJoinMessage" in plugins and "Essentials" in plugins:
-                    embed_var.add_field(name="❌ DisableJoinMessage",
-                                        value="You probably don't need DisableJoinMessage because Essentials already has its features. ")
+                if not YAML_ERROR:
+                    for plugin in plugins:
+                        for stored_plugin in TIMINGS_CHECK["plugins"]["paper"]:
+                            if plugin == stored_plugin["name"]:
+                                embed_var.add_field(**create_field(stored_plugin))
+                        if "purpur" in r["timingsMaster"]["config"] and "purpur" in TIMINGS_CHECK["plugins"]:
+                            for stored_plugin in TIMINGS_CHECK["plugins"]["purpur"]:
+                                if plugin == stored_plugin["name"]:
+                                    embed_var.add_field(**create_field(stored_plugin))
+                else:
+                    embed_var.add_field(name="Error loading YAML file",
+                                        value=YAML_ERROR)
                 for plugin in plugins:
                     if "songoda" in r["timingsMaster"]["plugins"][plugin]["authors"].casefold():
                         if plugin == "EpicHeads":
@@ -269,30 +188,11 @@ class Timings(commands.Cog):
                                                 value="This plugin was made by Songoda. Songoda resources are poorly developed and often cause problems. You should find an alternative such as [HeadsPlus](spigotmc.org/resources/headsplus-»-1-8-1-16-4.40265/) or [HeadDatabase](https://www.spigotmc.org/resources/head-database.14280/).")
                         elif plugin == "UltimateStacker":
                             embed_var.add_field(name="❌ UltimateStacker",
-                                                value="Stacking plugins actually cause more lag. "
+                                                value="Stacking plugins actually causes more lag. "
                                                       "Remove UltimateStacker.")
                         else:
                             embed_var.add_field(name="❌ " + plugin,
                                                 value="This plugin was made by Songoda. Songoda resources are poorly developed and often cause problems. You should find an alternative.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                using_purpur = "purpur" in r["timingsMaster"]["config"]
-                if using_purpur:
-                    plugins = r["timingsMaster"]["plugins"]
-                    if "SilkSpawners" in plugins:
-                        embed_var.add_field(name="❌ SilkSpawners",
-                                            value="You probably don't need SilkSpawners as Purpur already has its features. "
-                                                  "Remove SilkSpawners.")
-                    if "MineableSpawners" in plugins:
-                        embed_var.add_field(name="❌ MineableSpawners",
-                                            value="You probably don't need MineableSpawners as Purpur already has its features. "
-                                                  "Remove MineableSpawners.")
-                    if "VillagerLobotomizatornator" in plugins:
-                        embed_var.add_field(name="❌ LimitPillagers",
-                                            value="You probably don't need VillagerLobotomizatornator as Purpur already adds its features. "
-                                                  "Enable villager.lobotomize.enabled in purpur.yml.")
             except KeyError:
                 unchecked = unchecked + 1
 
@@ -971,6 +871,16 @@ class Timings(commands.Cog):
             embed_var.description = "||" + str(unchecked) + " missing configuration optimizations due to your server version.||"
         await message.reply(embed=embed_var)
 
+def create_field(option):
+    field = {"name": option["name"],
+            "value": option["value"]}
+    if "prefix" in option:
+        field["name"] = option["prefix"] + field["name"]
+    if "suffix" in option:
+        field["name"] = field["name"] + option["suffix"]
+    if "inline" in option:
+        field["inline"] = option["inline"]
+    return field
 
 def setup(bot):
     bot.add_cog(Timings(bot))

--- a/cogs/timings.py
+++ b/cogs/timings.py
@@ -65,62 +65,35 @@ class Timings(commands.Cog):
             try:
                 version = r["timingsMaster"]["version"].lower()
                 if "version" in TIMINGS_CHECK:
-                    if TIMINGS_CHECK["version"] in version:
+                    if TIMINGS_CHECK["version"] not in version:
                         embed_var.add_field(name="❌ Legacy Build",
-                                            value="Update to " + TIMINGS_CHECK["server"]["version"])
+                                            value="Update to " + TIMINGS_CHECK["version"])
                 if "servers" in TIMINGS_CHECK:
                     for server in TIMINGS_CHECK["servers"]:
                         if server["name"] in version:
                             embed_var.add_field(**create_field(server))
                             break
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                if "config" in TIMINGS_CHECK:
-                    server_properties = None
-                    bukkit = None
-                    spigot = None
-                    paper = None
-                    purpur = None
-                    if "server.properties" in r["timingsMaster"]["config"]:
-                        server_properties = r["timingsMaster"]["config"]["server.properties"]
-                    if "bukkit" in r["timingsMaster"]["config"]:
-                        bukkit = r["timingsMaster"]["config"]["bukkit"]
-                    if "spigot" in r["timingsMaster"]["config"]:
-                        spigot = r["timingsMaster"]["config"]["spigot"]
-                    if "paper" in r["timingsMaster"]["config"]:
-                        paper = r["timingsMaster"]["config"]["paper"]
-                    if "purpur" in r["timingsMaster"]["config"]:
-                        purpur = r["timingsMaster"]["config"]["purpur"]
-
-                    for config_name in TIMINGS_CHECK["config"]:
-                        config = TIMINGS_CHECK["config"][config_name]
-                        for option_name in config:
-                            option = config[option_name]
-                            for expression in option["expressions"]:
-                                if not eval(expression):
-                                    continue
-                                embed_var.add_field(**create_field({**{"name": option_name}, **option}))
-
-            except KeyError:
-                unchecked = unchecked + 1
+            except KeyError as key:
+                print("Missing: " + str(key))
+                unchecked += 1
 
             try:
                 timing_cost = int(r["timingsMaster"]["system"]["timingcost"])
                 if timing_cost > 300:
                     embed_var.add_field(name="❌ Timingcost",
                                         value="Your timingcost is " + str(timing_cost) + ". Find a [better host](https://www.birdflop.com).")
-            except KeyError:
-                unchecked = unchecked + 1
+            except KeyError as key:
+                print("Missing: " + str(key))
+                unchecked += 1
 
             try:
                 jvm_version = r["timingsMaster"]["system"]["jvmversion"]
                 if jvm_version.startswith("1.8.") or jvm_version.startswith("9.") or jvm_version.startswith("10."):
                     embed_var.add_field(name="❌ Java Version",
                                         value="You are using Java " + jvm_version + ". Update to [Java 11](https://adoptopenjdk.net/installation.html).")
-            except KeyError:
-                unchecked = unchecked + 1
+            except KeyError as key:
+                print("Missing: " + str(key))
+                unchecked += 1
 
             try:
                 flags = r["timingsMaster"]["system"]["flags"]
@@ -169,8 +142,10 @@ class Timings(commands.Cog):
                 else:
                     embed_var.add_field(name="❌ Aikar's Flags",
                                         value="Use [Aikar's flags](https://aikar.co/2018/07/02/tuning-the-jvm-g1gc-garbage-collector-flags-for-minecraft/).")
-            except KeyError:
-                unchecked = unchecked + 1
+            except KeyError as key:
+                print("Missing: " + str(key))
+                unchecked += 1
+
             try:
                 cpu = int(r["timingsMaster"]["system"]["cpu"])
                 if cpu == 1:
@@ -179,162 +154,52 @@ class Timings(commands.Cog):
                 if cpu == 2:
                     embed_var.add_field(name="❌ Threads",
                                         value="You have only " + str(cpu) + " threads. Find a [better host](https://www.birdflop.com).")
-            except KeyError:
-                unchecked = unchecked + 1
+            except KeyError as key:
+                print("Missing: " + str(key))
+                unchecked += 1
 
-            try:
-                plugins = r["timingsMaster"]["plugins"]
-                if not YAML_ERROR:
+            plugins = r["timingsMaster"]["plugins"] if "plugins" in r["timingsMaster"] else None
+            server_properties = r["timingsMaster"]["config"]["server.properties"] if "server.properties" in r["timingsMaster"]["config"] else None
+            bukkit = r["timingsMaster"]["config"]["bukkit"] if "bukkit" in r["timingsMaster"]["config"] else None
+            spigot = r["timingsMaster"]["config"]["spigot"] if "spigot" in r["timingsMaster"]["config"] else None
+            paper = r["timingsMaster"]["config"]["paper"] if "paper" in r["timingsMaster"]["config"] else None
+            purpur = r["timingsMaster"]["config"]["purpur"] if "purpur" in r["timingsMaster"]["config"] else None
+            if not YAML_ERROR:
+                if "plugins" in TIMINGS_CHECK:
                     for server_name in TIMINGS_CHECK["plugins"]:
                         if server_name in r["timingsMaster"]["config"]:
                             for plugin in plugins:
                                 for plugin_name in TIMINGS_CHECK["plugins"][server_name]:
                                     if plugin == plugin_name:
                                         stored_plugin = TIMINGS_CHECK["plugins"][server_name][plugin_name]
-                                        stored_plugin["name"] = plugin_name
-                                        embed_var.add_field(**create_field(stored_plugin))
-                else:
-                    embed_var.add_field(name="Error loading YAML file",
-                                        value=YAML_ERROR)
-                for plugin in plugins:
-                    if "songoda" in r["timingsMaster"]["plugins"][plugin]["authors"].casefold():
-                        if plugin == "EpicHeads":
-                            embed_var.add_field(name="❌ EpicHeads",
-                                                value="This plugin was made by Songoda. Songoda resources are poorly developed and often cause problems. You should find an alternative such as [HeadsPlus](spigotmc.org/resources/headsplus-»-1-8-1-16-4.40265/) or [HeadDatabase](https://www.spigotmc.org/resources/head-database.14280/).")
-                        elif plugin == "UltimateStacker":
-                            embed_var.add_field(name="❌ UltimateStacker",
-                                                value="Stacking plugins actually causes more lag. "
-                                                      "Remove UltimateStacker.")
-                        else:
-                            embed_var.add_field(name="❌ " + plugin,
-                                                value="This plugin was made by Songoda. Songoda resources are poorly developed and often cause problems. You should find an alternative.")
-            except KeyError:
-                unchecked = unchecked + 1
+                                        if isinstance(stored_plugin, dict):
+                                            stored_plugin["name"] = plugin_name
+                                            embed_var.add_field(**create_field(stored_plugin))
+                                        else:
+                                            eval_field(embed_var, stored_plugin, plugin_name, unchecked, plugins, server_properties, bukkit, spigot, paper, purpur)
+                                if "songoda" in r["timingsMaster"]["plugins"][plugin]["authors"].casefold():
+                                    if plugin == "EpicHeads":
+                                        embed_var.add_field(name="❌ EpicHeads",
+                                                            value="This plugin was made by Songoda. Songoda resources are poorly developed and often cause problems. You should find an alternative such as [HeadsPlus](spigotmc.org/resources/headsplus-»-1-8-1-16-4.40265/) or [HeadDatabase](https://www.spigotmc.org/resources/head-database.14280/).")
+                                    elif plugin == "UltimateStacker":
+                                        embed_var.add_field(name="❌ UltimateStacker",
+                                                            value="Stacking plugins actually causes more lag. "
+                                                                    "Remove UltimateStacker.")
+                                    else:
+                                        embed_var.add_field(name="❌ " + plugin,
+                                                            value="This plugin was made by Songoda. Songoda resources are poorly developed and often cause problems. You should find an alternative.")
+                if "config" in TIMINGS_CHECK:
+                    for config_name in TIMINGS_CHECK["config"]:
+                        config = TIMINGS_CHECK["config"][config_name]
+                        for option_name in config:
+                            option = config[option_name]
+                            eval_field(embed_var, option, option_name, unchecked, plugins, server_properties, bukkit, spigot, paper, purpur)
+            else:
+                embed_var.add_field(name="Error loading YAML file",
+                                    value=YAML_ERROR)
 
-            try:
-                plugins = r["timingsMaster"]["plugins"]
-                if "PhantomSMP" in plugins:
-                    phantoms_only_insomniacs = r["timingsMaster"]["config"]["paper"]["world-settings"]["default"][
-                        "phantoms-only-attack-insomniacs"]
-                    if phantoms_only_insomniacs == "false":
-                        embed_var.add_field(name="❌ PhantomSMP",
-                                            value="You probably don't need PhantomSMP as Paper already has its features. "
-                                                  "Remove PhantomSMP.")
-                    else:
-                        embed_var.add_field(name="❌ PhantomSMP",
-                                            value="You probably don't need PhantomSMP as Paper already has its features. "
-                                                  "Enable phantoms-only-attack-insomniacs in paper.yml.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                network_compression_threshold = int(
-                    r["timingsMaster"]["config"]["server.properties"]["network-compression-threshold"])
-                bungeecord = r["timingsMaster"]["config"]["spigot"]["settings"]["bungeecord"]
-                if network_compression_threshold <= 256 and bungeecord == "false":
-                    embed_var.add_field(name="❌ network-compression-threshold",
-                                        value="Increase this in server.properties. Recommended: 512.")
-                if network_compression_threshold != -1 and bungeecord == "true":
-                    embed_var.add_field(name="❌ network-compression-threshold",
-                                        value="Set this to -1 in server.properties for a bungee server like yours.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                mob_spawn_range = int(r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["mob-spawn-range"])
-                spigot_view_distance = r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["view-distance"]
-                if spigot_view_distance == "default":
-                    view_distance = int(r["timingsMaster"]["config"]["server.properties"]["view-distance"])
-                    if mob_spawn_range >= 8 and view_distance <= 6:
-                        embed_var.add_field(name="❌ mob-spawn-range",
-                                            value="Decrease this in spigot.yml. "
-                                                  "Recommended: " + str(view_distance - 1) + ".")
-                elif mob_spawn_range >= 8 and int(spigot_view_distance) <= 6:
-                            embed_var.add_field(name="❌ mob-spawn-range",
-                                                value="Decrease this in spigot.yml. "
-                                                      "Recommended: " + str(int(spigot_view_distance) - 1) + ".")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                raiders_entity_activation_range = int(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"][
-                        "raiders"])
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                flying_monsters_entity_activation_range = int(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"][
-                        "flying-monsters"])
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                wake_up_inactive_villagers_every = int(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"][
-                        "wake-up-inactive"]["villagers-every"])
-            except KeyError:
-                unchecked = unchecked + 1
-
-
-            try:
-                wake_up_inactive_animals_every = int(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"][
-                        "wake-up-inactive"]["animals-every"])
-
-            except KeyError:
-                unchecked = unchecked + 1
-
-
-
-            try:
-                wake_up_inactive_flying_monsters_every = int(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"][
-                        "wake-up-inactive"]["flying-monsters-every"])
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                wake_up_inactive_monsters_every = int(
-                    r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"]["entity-activation-range"][
-                        "wake-up-inactive"]["monsters-every"])
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                no_tick_view_distance = int(
-                    r["timingsMaster"]["config"]["paper"]["world-settings"]["default"]["viewdistances"][
-                        "no-tick-view-distance"])
-                if no_tick_view_distance == -1:
-                    spigot_view_distance = r["timingsMaster"]["config"]["spigot"]["world-settings"]["default"][
-                        "view-distance"]
-                    if spigot_view_distance == "default":
-                        view_distance = int(r["timingsMaster"]["config"]["server.properties"]["view-distance"])
-                        if view_distance >= 4:
-                            embed_var.add_field(name="❌ no-tick-view-distance",
-                                                value="Set a value in paper.yml. "
-                                                      "Recommended: " + str(view_distance) + ". And reduce view-distance in server.properties. Recommended: 3.")
-                    elif int(spigot_view_distance) >= 4:
-                        embed_var.add_field(name="❌ no-tick-view-distance",
-                                            value="Set a value in paper.yml. "
-                                                  "Recommended: " + spigot_view_distance + ". And reduce view-distance in spigot.yml. Recommended: 3.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-            try:
-                use_alternate_keepalive = r["timingsMaster"]["config"]["purpur"]["settings"]["use-alternate-keepalive"]
-                plugins = r["timingsMaster"]["plugins"]
-                if use_alternate_keepalive == "false" and "TCPShield" not in plugins:
-                    embed_var.add_field(name="❌ use-alternate-keepalive",
-                                        value="Enable this in purpur.yml.")
-                if use_alternate_keepalive == "true" and "TCPShield" in plugins:
-                    embed_var.add_field(name="❌ use-alternate-keepalive",
-                                        value="Disable this in purpur.yml. It causes issues with TCPShield.")
-            except KeyError:
-                unchecked = unchecked + 1
-
-        except ValueError:
+        except ValueError as bruh:
+            print(bruh)
             embed_var.add_field(name="❌ Invalid Configuration",
                                 value="At least one of your configuration files had an invalid data type.")
 
@@ -348,8 +213,31 @@ class Timings(commands.Cog):
         if issue_count >= 25:
             embed_var.insert_field_at(index=24, name="Plus " + str(issue_count - 24) + " more recommendations", value="Create a new timings report after resolving some of the above issues to see more.")
         if unchecked > 0:
-            embed_var.description = "||" + str(unchecked) + " missing configuration optimizations due to your server version.||"
+            embed_var.description = "||" + str(unchecked) + " missing configuration optimizations.||"
         await message.reply(embed=embed_var)
+
+def eval_field(embed_var, option, option_name, unchecked, plugins=None, server_properties=None, bukkit=None, spigot=None, paper=None, purpur=None):
+    try:
+        for option_data in option:
+            add_to_field = True
+            for expression in option_data["expressions"]:
+                if ("server_properties" in expression and server_properties or
+                    "bukkit" in expression and bukkit or
+                    "spigot" in expression and spigot or
+                    "paper" in expression and paper or
+                    "purpur" in expression and purpur or
+                    "plugins" in expression and plugins):
+                    if not eval(expression):
+                        add_to_field = False
+                        break
+            if add_to_field:
+                """ f strings don't like newlines so we replace the newlines with placeholder text before we eval """
+                option_data["value"] = eval('f"""' + option_data["value"].replace("\n", "\\|n\\") + '"""').replace("\\|n\\", "\n")
+                embed_var.add_field(**create_field({**{"name": option_name}, **option_data}))
+                break
+    except KeyError as key:
+        print("Missing: " + str(key))
+        unchecked += 1
 
 def create_field(option):
     field = {"name": option["name"],

--- a/cogs/timings_check.yml
+++ b/cogs/timings_check.yml
@@ -13,148 +13,148 @@ servers:
     "||Purpur has more optimizations but is generally less supported. "
     "Consider using [Purpur](https://ci.pl3x.net/job/Purpur/).||"
 plugins:
-    paper:
-        ClearLag:
-            prefix: "⚠ "
-            value: |-
-                "Plugins that claim to remove lag actually cause more lag. "
-                "Remove ClearLag."
-        LagAssist:
-            prefix: "⚠ "
-            value: |-
-                "LagAssist should only be used for analytics and preventative measures."
-                "All other features of the plugin should be disabled."
-        NoChunkLag:
-            prefix: "⚠ "
-            value: |-
-                "Plugins that claim to remove lag actually cause more lag. "
-                "Remove NoChunkLag."
-        ServerBooster:
-            prefix: "⚠ "
-            value: |-
-                "Plugins that claim to remove lag actually cause more lag. "
-                "Remove ServerBooster."
-        MobLimiter:
-            prefix: "⚠ "
-            value: |-
-                "You probably don't need MobLimiter as Bukkit already has its features. "
-                "Remove MobLimiter."
-        BookLimiter:
-            prefix: "⚠ "
-            value: |-
-                "You probably don't need BookLimiter as Paper already has its features. "
-                "Remove BookLimiter."
-        LimitPillagers:
-            prefix: "⚠ "
-            value: |-
-                "You probably don't need LimitPillagers as Paper already adds its features. "
-                "Remove LimitPillagers."
-        VillagerOptimiser:
-            prefix: "⚠ "
-            value: |-
-                "You probably don't need VillagerOptimiser as Paper already adds its features. "
-                "See entity-activation-range in spigot.yml."
-        StackMob:
-            prefix: "⚠ "
-            value: |-
-                "Stacking plugins actually cause more lag. "
-                "Remove StackMob."
-        Stacker:
-            prefix: "⚠ "
-            value: |-
-                "Stacking plugins actually cause more lag. "
-                "Remove Stacker."
-        MobStacker:
-            prefix: "⚠ "
-            value: |-
-                "Stacking plugins actually cause more lag. "
-                "Remove MobStacker."
-        WildStacker:
-            prefix: "⚠ "
-            value: |-
-                "Stacking plugins actually cause more lag. "
-                "Remove WildStacker."
-        SuggestionBlocker:
-            prefix: "⚠ "
-            value: |-
-                "You probably don't need SuggestionBlocker as Spigot already adds its features. "
-                "Set tab-complete to -1 in spigot.yml."
-        FastAsyncWorldEdit:
-            prefix: "⚠ "
-            value: |-
-                "FAWE can corrupt your world. "
-                "Consider replacing FAWE with [Worldedit](https://enginehub.org/worldedit/#downloads)."
-        CMI:
-            prefix: "⚠ "
-            value: |-
-                "CMI is a buggy plugin. "
-                "Consider replacing CMI with [EssentialsX](https://essentialsx.net/downloads.html)."
-        Spartan:
-            prefix: "⚠ "
-            value: |-
-                "Spartan is a laggy anticheat. "
-                "Consider replacing it with [Matrix](https://matrix.rip/), [NCP](https://ci.codemc.io/job/Updated-NoCheatPlus/job/Updated-NoCheatPlus/), or [AAC](https://www.spigotmc.org/resources/aac-advanced-anti-cheat-hack-kill-aura-blocker.6442/)."
-        IllegalStack:
-            prefix: "⚠ "
-            value: |-
-                "You probably don't need IllegalStack as Paper already has its features. "
-                "Remove IllegalStack."
-        ExploitFixer:
-            prefix: "⚠ "
-            value: |-
-                "You probably don't need ExploitFixer as Paper already has its features. "
-                "Remove ExploitFixer."
-        EntityTrackerFixer:
-            prefix: "⚠ "
-            value: |-
-                "You probably don't need EntityTrackerFixer as Paper already has its features. "
-                "Remove EntityTrackerFixer."
-        Orebfuscator:
-            prefix: "⚠ "
-            value: |-
-                "You probably don't need Orebfuscator as Paper already has its features. "
-                "Remove Orebfuscator."
-        ImageOnMap:
-            prefix: "⚠ "
-            value: |-
-                "This plugin has a [memory leak](https://github.com/zDevelopers/ImageOnMap/issues/104). If it is not essential, you should remove it. "
-                "Consider replacing it with [an alternative](https://www.spigotmc.org/resources/drmap.87368/)."
-        CrazyActions:
-            prefix: "⚠ "
-            value: |-
-                "CrazyAuctions is a laggy plugin, even according to the developer. "
-                "Consider replacing it with [AuctionHouse](https://www.spigotmc.org/resources/auctionhouse.61836/)."
-        GroupManager:
-            prefix: "⚠ "
-            value: |-
-                "GroupManager is an outdated permission plugin. "
-                "Consider replacing it with [LuckPerms](https://ci.lucko.me/job/LuckPerms/1243/artifact/bukkit/build/libs/LuckPerms-Bukkit-5.2.77.jar)."
-        PermissionsEx:
-            prefix: "⚠ "
-            value: |-
-                "PermissionsEx is an outdated permission plugin. "
-                "Consider replacing it with [LuckPerms](https://ci.lucko.me/job/LuckPerms/1243/artifact/bukkit/build/libs/LuckPerms-Bukkit-5.2.77.jar)."
-        bPermissions:
-            prefix: "⚠ "
-            value: |-
-                "bPermissions is an outdated permission plugin. "
-                "Consider replacing it with [LuckPerms](https://ci.lucko.me/job/LuckPerms/1243/artifact/bukkit/build/libs/LuckPerms-Bukkit-5.2.77.jar)."
-    purpur:
-        SilkSpawners:
-            prefix: "⚠ "
-            value: |-
-                "You probably don't need SilkSpawners as Purpur already has its features. "
-                "Remove SilkSpawners."
-        MineableSpawners:
-            prefix: "⚠ "
-            value: |-
-                "You probably don't need MineableSpawners as Purpur already has its features. "
-                "Remove MineableSpawners."
-        VillagerLobotomizatornator:
-            prefix: "⚠ "
-            value: |-
-                "You probably don't need VillagerLobotomizatornator as Purpur already adds its features. "
-                "Enable villager.lobotomize.enabled in purpur.yml."
+  paper:
+    ClearLag:
+      prefix: "⚠ "
+      value: |-
+        "Plugins that claim to remove lag actually cause more lag. "
+        "Remove ClearLag."
+    LagAssist:
+      prefix: "⚠ "
+      value: |-
+        "LagAssist should only be used for analytics and preventative measures."
+        "All other features of the plugin should be disabled."
+    NoChunkLag:
+      prefix: "⚠ "
+      value: |-
+        "Plugins that claim to remove lag actually cause more lag. "
+        "Remove NoChunkLag."
+    ServerBooster:
+      prefix: "⚠ "
+      value: |-
+        "Plugins that claim to remove lag actually cause more lag. "
+        "Remove ServerBooster."
+    MobLimiter:
+      prefix: "⚠ "
+      value: |-
+        "You probably don't need MobLimiter as Bukkit already has its features. "
+        "Remove MobLimiter."
+    BookLimiter:
+      prefix: "⚠ "
+      value: |-
+        "You probably don't need BookLimiter as Paper already has its features. "
+        "Remove BookLimiter."
+    LimitPillagers:
+      prefix: "⚠ "
+      value: |-
+        "You probably don't need LimitPillagers as Paper already adds its features. "
+        "Remove LimitPillagers."
+    VillagerOptimiser:
+      prefix: "⚠ "
+      value: |-
+        "You probably don't need VillagerOptimiser as Paper already adds its features. "
+        "See entity-activation-range in spigot.yml."
+    StackMob:
+      prefix: "⚠ "
+      value: |-
+        "Stacking plugins actually cause more lag. "
+        "Remove StackMob."
+    Stacker:
+      prefix: "⚠ "
+      value: |-
+        "Stacking plugins actually cause more lag. "
+        "Remove Stacker."
+    MobStacker:
+      prefix: "⚠ "
+      value: |-
+        "Stacking plugins actually cause more lag. "
+        "Remove MobStacker."
+    WildStacker:
+      prefix: "⚠ "
+      value: |-
+        "Stacking plugins actually cause more lag. "
+        "Remove WildStacker."
+    SuggestionBlocker:
+      prefix: "⚠ "
+      value: |-
+        "You probably don't need SuggestionBlocker as Spigot already adds its features. "
+        "Set tab-complete to -1 in spigot.yml."
+    FastAsyncWorldEdit:
+      prefix: "⚠ "
+      value: |-
+        "FAWE can corrupt your world. "
+        "Consider replacing FAWE with [Worldedit](https://enginehub.org/worldedit/#downloads)."
+    CMI:
+      prefix: "⚠ "
+      value: |-
+        "CMI is a buggy plugin. "
+        "Consider replacing CMI with [EssentialsX](https://essentialsx.net/downloads.html)."
+    Spartan:
+      prefix: "⚠ "
+      value: |-
+        "Spartan is a laggy anticheat. "
+        "Consider replacing it with [Matrix](https://matrix.rip/), [NCP](https://ci.codemc.io/job/Updated-NoCheatPlus/job/Updated-NoCheatPlus/), or [AAC](https://www.spigotmc.org/resources/aac-advanced-anti-cheat-hack-kill-aura-blocker.6442/)."
+    IllegalStack:
+      prefix: "⚠ "
+      value: |-
+        "You probably don't need IllegalStack as Paper already has its features. "
+        "Remove IllegalStack."
+    ExploitFixer:
+      prefix: "⚠ "
+      value: |-
+        "You probably don't need ExploitFixer as Paper already has its features. "
+        "Remove ExploitFixer."
+    EntityTrackerFixer:
+      prefix: "⚠ "
+      value: |-
+        "You probably don't need EntityTrackerFixer as Paper already has its features. "
+        "Remove EntityTrackerFixer."
+    Orebfuscator:
+      prefix: "⚠ "
+      value: |-
+        "You probably don't need Orebfuscator as Paper already has its features. "
+        "Remove Orebfuscator."
+    ImageOnMap:
+      prefix: "⚠ "
+      value: |-
+        "This plugin has a [memory leak](https://github.com/zDevelopers/ImageOnMap/issues/104). If it is not essential, you should remove it. "
+        "Consider replacing it with [an alternative](https://www.spigotmc.org/resources/drmap.87368/)."
+    CrazyActions:
+      prefix: "⚠ "
+      value: |-
+        "CrazyAuctions is a laggy plugin, even according to the developer. "
+        "Consider replacing it with [AuctionHouse](https://www.spigotmc.org/resources/auctionhouse.61836/)."
+    GroupManager:
+      prefix: "⚠ "
+      value: |-
+        "GroupManager is an outdated permission plugin. "
+        "Consider replacing it with [LuckPerms](https://ci.lucko.me/job/LuckPerms/1243/artifact/bukkit/build/libs/LuckPerms-Bukkit-5.2.77.jar)."
+    PermissionsEx:
+      prefix: "⚠ "
+      value: |-
+        "PermissionsEx is an outdated permission plugin. "
+        "Consider replacing it with [LuckPerms](https://ci.lucko.me/job/LuckPerms/1243/artifact/bukkit/build/libs/LuckPerms-Bukkit-5.2.77.jar)."
+    bPermissions:
+      prefix: "⚠ "
+      value: |-
+        "bPermissions is an outdated permission plugin. "
+        "Consider replacing it with [LuckPerms](https://ci.lucko.me/job/LuckPerms/1243/artifact/bukkit/build/libs/LuckPerms-Bukkit-5.2.77.jar)."
+  purpur:
+    SilkSpawners:
+      prefix: "⚠ "
+      value: |-
+        "You probably don't need SilkSpawners as Purpur already has its features. "
+        "Remove SilkSpawners."
+    MineableSpawners:
+      prefix: "⚠ "
+      value: |-
+        "You probably don't need MineableSpawners as Purpur already has its features. "
+        "Remove MineableSpawners."
+    VillagerLobotomizatornator:
+      prefix: "⚠ "
+      value: |-
+        "You probably don't need VillagerLobotomizatornator as Purpur already adds its features. "
+        "Enable villager.lobotomize.enabled in purpur.yml."
 config:
   server.properties:
     online-mode:

--- a/cogs/timings_check.yml
+++ b/cogs/timings_check.yml
@@ -1,160 +1,179 @@
 ---
+# raiders_entity_activation_range = int(spigot["world-settings"]["default"]["entity-activation-range"]["raiders"])
+# flying_monsters_entity_activation_range = int(spigot["world-settings"]["default"]["entity-activation-range"]["flying-monsters"])
+# wake_up_inactive_villagers_every = int(spigot["world-settings"]["default"]["entity-activation-range"]["wake-up-inactive"]["villagers-every"])
+# wake_up_inactive_animals_every = int(spigot["world-settings"]["default"]["entity-activation-range"]["wake-up-inactive"]["animals-every"])
+# wake_up_inactive_flying_monsters_every = int(spigot["world-settings"]["default"]["entity-activation-range"]["wake-up-inactive"]["flying-monsters-every"])
+# wake_up_inactive_monsters_every = int(spigot["world-settings"]["default"]["entity-activation-range"]["wake-up-inactive"]["monsters-every"])
 version: "1.16.4"
 servers:
 - name: "yatopia"
   prefix: "❌ "
   value: |-
-    "Yatopia is prone to bugs."
-    "Consider using [Purpur](https://ci.pl3x.net/job/Purpur/)."
+    Yatopia is prone to bugs.
+    Consider using [Purpur](https://ci.pl3x.net/job/Purpur/).
 - name: "paper"
   prefix: "||❌ "
   suffix: "||"
   value: |-
-    "||Purpur has more optimizations but is generally less supported. "
-    "Consider using [Purpur](https://ci.pl3x.net/job/Purpur/).||"
+    ||Purpur has more optimizations but is generally less supported. 
+    Consider using [Purpur](https://ci.pl3x.net/job/Purpur/).||
 plugins:
   paper:
     ClearLag:
       prefix: "⚠ "
       value: |-
-        "Plugins that claim to remove lag actually cause more lag. "
-        "Remove ClearLag."
+        Plugins that claim to remove lag actually cause more lag. 
+        Remove ClearLag.
     LagAssist:
       prefix: "⚠ "
       value: |-
-        "LagAssist should only be used for analytics and preventative measures."
-        "All other features of the plugin should be disabled."
+        LagAssist should only be used for analytics and preventative measures.
+        All other features of the plugin should be disabled.
     NoChunkLag:
       prefix: "⚠ "
       value: |-
-        "Plugins that claim to remove lag actually cause more lag. "
-        "Remove NoChunkLag."
+        Plugins that claim to remove lag actually cause more lag. 
+        Remove NoChunkLag.
     ServerBooster:
       prefix: "⚠ "
       value: |-
-        "Plugins that claim to remove lag actually cause more lag. "
-        "Remove ServerBooster."
+        Plugins that claim to remove lag actually cause more lag. 
+        Remove ServerBooster.
     MobLimiter:
       prefix: "⚠ "
       value: |-
-        "You probably don't need MobLimiter as Bukkit already has its features. "
-        "Remove MobLimiter."
+        You probably don't need MobLimiter as Bukkit already has its features. 
+        Remove MobLimiter.
     BookLimiter:
       prefix: "⚠ "
       value: |-
-        "You probably don't need BookLimiter as Paper already has its features. "
-        "Remove BookLimiter."
+        You probably don't need BookLimiter as Paper already has its features. 
+        Remove BookLimiter.
     LimitPillagers:
       prefix: "⚠ "
       value: |-
-        "You probably don't need LimitPillagers as Paper already adds its features. "
-        "Remove LimitPillagers."
+        You probably don't need LimitPillagers as Paper already adds its features. 
+        Remove LimitPillagers.
     VillagerOptimiser:
       prefix: "⚠ "
       value: |-
-        "You probably don't need VillagerOptimiser as Paper already adds its features. "
-        "See entity-activation-range in spigot.yml."
+        You probably don't need VillagerOptimiser as Paper already adds its features. 
+        See entity-activation-range in [spigot.yml](http://bit.ly/spiconf).
     StackMob:
       prefix: "⚠ "
       value: |-
-        "Stacking plugins actually cause more lag. "
-        "Remove StackMob."
+        Stacking plugins actually cause more lag. 
+        Remove StackMob.
     Stacker:
       prefix: "⚠ "
       value: |-
-        "Stacking plugins actually cause more lag. "
-        "Remove Stacker."
+        Stacking plugins actually cause more lag. 
+        Remove Stacker.
     MobStacker:
       prefix: "⚠ "
       value: |-
-        "Stacking plugins actually cause more lag. "
-        "Remove MobStacker."
+        Stacking plugins actually cause more lag. 
+        Remove MobStacker.
     WildStacker:
       prefix: "⚠ "
       value: |-
-        "Stacking plugins actually cause more lag. "
-        "Remove WildStacker."
+        Stacking plugins actually cause more lag. 
+        Remove WildStacker.
     SuggestionBlocker:
       prefix: "⚠ "
       value: |-
-        "You probably don't need SuggestionBlocker as Spigot already adds its features. "
-        "Set tab-complete to -1 in spigot.yml."
+        You probably don't need SuggestionBlocker as Spigot already adds its features. 
+        Set tab-complete to -1 in [spigot.yml](http://bit.ly/spiconf).
     FastAsyncWorldEdit:
       prefix: "⚠ "
       value: |-
-        "FAWE can corrupt your world. "
-        "Consider replacing FAWE with [Worldedit](https://enginehub.org/worldedit/#downloads)."
+        FAWE can corrupt your world. 
+        Consider replacing FAWE with [Worldedit](https://enginehub.org/worldedit/#downloads).
     CMI:
       prefix: "⚠ "
       value: |-
-        "CMI is a buggy plugin. "
-        "Consider replacing CMI with [EssentialsX](https://essentialsx.net/downloads.html)."
+        CMI is a buggy plugin. 
+        Consider replacing CMI with [EssentialsX](https://essentialsx.net/downloads.html).
     Spartan:
       prefix: "⚠ "
       value: |-
-        "Spartan is a laggy anticheat. "
-        "Consider replacing it with [Matrix](https://matrix.rip/), [NCP](https://ci.codemc.io/job/Updated-NoCheatPlus/job/Updated-NoCheatPlus/), or [AAC](https://www.spigotmc.org/resources/aac-advanced-anti-cheat-hack-kill-aura-blocker.6442/)."
+        Spartan is a laggy anticheat. 
+        Consider replacing it with [Matrix](https://matrix.rip/), [NCP](https://ci.codemc.io/job/Updated-NoCheatPlus/job/Updated-NoCheatPlus/), or [AAC](https://www.spigotmc.org/resources/aac-advanced-anti-cheat-hack-kill-aura-blocker.6442/).
     IllegalStack:
       prefix: "⚠ "
       value: |-
-        "You probably don't need IllegalStack as Paper already has its features. "
-        "Remove IllegalStack."
+        You probably don't need IllegalStack as Paper already has its features. 
+        Remove IllegalStack.
     ExploitFixer:
       prefix: "⚠ "
       value: |-
-        "You probably don't need ExploitFixer as Paper already has its features. "
-        "Remove ExploitFixer."
+        You probably don't need ExploitFixer as Paper already has its features. 
+        Remove ExploitFixer.
     EntityTrackerFixer:
       prefix: "⚠ "
       value: |-
-        "You probably don't need EntityTrackerFixer as Paper already has its features. "
-        "Remove EntityTrackerFixer."
+        You probably don't need EntityTrackerFixer as Paper already has its features. 
+        Remove EntityTrackerFixer.
     Orebfuscator:
       prefix: "⚠ "
       value: |-
-        "You probably don't need Orebfuscator as Paper already has its features. "
-        "Remove Orebfuscator."
+        You probably don't need Orebfuscator as Paper already has its features. 
+        Remove Orebfuscator.
     ImageOnMap:
       prefix: "⚠ "
       value: |-
-        "This plugin has a [memory leak](https://github.com/zDevelopers/ImageOnMap/issues/104). If it is not essential, you should remove it. "
-        "Consider replacing it with [an alternative](https://www.spigotmc.org/resources/drmap.87368/)."
+        This plugin has a [memory leak](https://github.com/zDevelopers/ImageOnMap/issues/104). If it is not essential, you should remove it. 
+        Consider replacing it with [an alternative](https://www.spigotmc.org/resources/drmap.87368/).
     CrazyActions:
       prefix: "⚠ "
       value: |-
-        "CrazyAuctions is a laggy plugin, even according to the developer. "
-        "Consider replacing it with [AuctionHouse](https://www.spigotmc.org/resources/auctionhouse.61836/)."
+        CrazyAuctions is a laggy plugin, even according to the developer. 
+        Consider replacing it with [AuctionHouse](https://www.spigotmc.org/resources/auctionhouse.61836/).
     GroupManager:
       prefix: "⚠ "
       value: |-
-        "GroupManager is an outdated permission plugin. "
-        "Consider replacing it with [LuckPerms](https://ci.lucko.me/job/LuckPerms/1243/artifact/bukkit/build/libs/LuckPerms-Bukkit-5.2.77.jar)."
+        GroupManager is an outdated permission plugin. 
+        Consider replacing it with [LuckPerms](https://ci.lucko.me/job/LuckPerms/1243/artifact/bukkit/build/libs/LuckPerms-Bukkit-5.2.77.jar).
     PermissionsEx:
       prefix: "⚠ "
       value: |-
-        "PermissionsEx is an outdated permission plugin. "
-        "Consider replacing it with [LuckPerms](https://ci.lucko.me/job/LuckPerms/1243/artifact/bukkit/build/libs/LuckPerms-Bukkit-5.2.77.jar)."
+        PermissionsEx is an outdated permission plugin. 
+        Consider replacing it with [LuckPerms](https://ci.lucko.me/job/LuckPerms/1243/artifact/bukkit/build/libs/LuckPerms-Bukkit-5.2.77.jar).
     bPermissions:
       prefix: "⚠ "
       value: |-
-        "bPermissions is an outdated permission plugin. "
-        "Consider replacing it with [LuckPerms](https://ci.lucko.me/job/LuckPerms/1243/artifact/bukkit/build/libs/LuckPerms-Bukkit-5.2.77.jar)."
+        bPermissions is an outdated permission plugin. 
+        Consider replacing it with [LuckPerms](https://ci.lucko.me/job/LuckPerms/1243/artifact/bukkit/build/libs/LuckPerms-Bukkit-5.2.77.jar).
+    PhantomSMP:
+    - expressions:
+      - paper["world-settings"]["default"]["phantoms-only-attack-insomniacs"] == "false"
+      prefix: "⚠ "
+      value: |-
+        You probably don't need PhantomSMP as Paper already has its features.
+        Remove PhantomSMP.
+    - expressions:
+      - paper["world-settings"]["default"]["phantoms-only-attack-insomniacs"] == "true"
+      prefix: "⚠ "
+      value: |-
+        You probably don't need PhantomSMP as Paper already has its features.
+        Enable phantoms-only-attack-insomniacs in [paper.yml](http://bit.ly/paperconf).
   purpur:
     SilkSpawners:
       prefix: "⚠ "
       value: |-
-        "You probably don't need SilkSpawners as Purpur already has its features. "
-        "Remove SilkSpawners."
+        You probably don't need SilkSpawners as Purpur already has its features. 
+        Remove SilkSpawners.
     MineableSpawners:
       prefix: "⚠ "
       value: |-
-        "You probably don't need MineableSpawners as Purpur already has its features. "
-        "Remove MineableSpawners."
+        You probably don't need MineableSpawners as Purpur already has its features. 
+        Remove MineableSpawners.
     VillagerLobotomizatornator:
       prefix: "⚠ "
       value: |-
-        "You probably don't need VillagerLobotomizatornator as Purpur already adds its features. "
-        "Enable villager.lobotomize.enabled in purpur.yml."
+        You probably don't need VillagerLobotomizatornator as Purpur already adds its features. 
+        Enable villager.lobotomize.enabled in [purpur.yml](http://bit.ly/purpurc).
 config:
   server.properties:
     online-mode:
@@ -163,223 +182,244 @@ config:
       - spigot["settings"]["bungeecord"] == "false"
       - paper["settings"]["velocity-support"]["online-mode"] == "false" or paper["settings"]["velocity-support"]["enabled"] == "false"
       prefix: "❌ "
-      value: "Enable this in server.properties for security."
+      value: "Enable this in [server.properties](http://bit.ly/servprop) for security."
+    network-compression-threshold:
+    - expressions:
+      - int(server_properties["network-compression-threshold"]) <= 256
+      - spigot["settings"]["bungeecord"] == "false"
+      prefix: "❌ "
+      value: "Increase this in [server.properties](http://bit.ly/servprop). Recommended: 512."
+    - expressions:
+      - int(server_properties["network-compression-threshold"]) != -1
+      - spigot["settings"]["bungeecord"] == "true"
+      prefix: "❌ "
+      value: "Set this to -1 in [server.properties](http://bit.ly/servprop) for a bungee server like yours."
   bukkit:
     chunk-gc.period-in-ticks:
     - expressions:
       - int(bukkit["chunk-gc"]["period-in-ticks"]) >= 600
       prefix: "❌ "
-      value: "Decrease this in bukkit.yml.\nRecommended: 400."
+      value: "Decrease this in [bukkit.yml](https://bukkit.gamepedia.com/Bukkit.yml).\nRecommended: 400."
     ticks-per.monster-spawns:
     - expressions:
       - int(bukkit["ticks-per"]["monster-spawns"]) == 1
       prefix: "❌ "
-      value: "Increase this in bukkit.yml.\nRecommended: 4."
+      value: "Increase this in [bukkit.yml](https://bukkit.gamepedia.com/Bukkit.yml).\nRecommended: 4."
     spawn-limits.monsters:
     - expressions:
       - int(bukkit["spawn-limits"]["monsters"]) >= 70
       prefix: "❌ "
-      value: "Decrease this in bukkit.yml.\nRecommended: 15."
+      value: "Decrease this in [bukkit.yml](https://bukkit.gamepedia.com/Bukkit.yml).\nRecommended: 15."
     spawn-limits.water-ambient:
     - expressions:
       - int(bukkit["spawn-limits"]["water-ambient"]) >= 20
       prefix: "❌ "
-      value: "Decrease this in bukkit.yml.\nRecommended: 2."
+      value: "Decrease this in [bukkit.yml](https://bukkit.gamepedia.com/Bukkit.yml).\nRecommended: 2."
     spawn-limits.ambient:
     - expressions:
       - int(bukkit["spawn-limits"]["ambient"]) >= 15
       prefix: "❌ "
-      value: "Decrease this in bukkit.yml.\nRecommended: 1."
+      value: "Decrease this in [bukkit.yml](https://bukkit.gamepedia.com/Bukkit.yml).\nRecommended: 1."
     spawn-limits.animals:
     - expressions:
       - int(bukkit["spawn-limits"]["animals"]) >= 10
       prefix: "❌ "
-      value: "Decrease this in bukkit.yml.\nRecommended: 3."
+      value: "Decrease this in [bukkit.yml](https://bukkit.gamepedia.com/Bukkit.yml).\nRecommended: 3."
     spawn-limits.water-animals:
     - expressions:
       - int(bukkit["spawn-limits"]["water-animals"]) >= 15
       prefix: "❌ "
-      value: "Decrease this in bukkit.yml.\nRecommended: 2."
+      value: "Decrease this in [bukkit.yml](https://bukkit.gamepedia.com/Bukkit.yml).\nRecommended: 2."
   spigot:
     view-distance:
     - expressions:
-      - server_properties["view-distance"] >= 10
+      - int(server_properties["view-distance"]) >= 10
       - spigot["world-settings"]["default"]["view-distance"] == "default"
       prefix: "❌ "
-      value: |-
-        "Decrease this from default (10) in spigot.yml. "
-        "Recommended: 3."
+      value: "Decrease this from default (10) in [spigot.yml](http://bit.ly/spiconf).\nRecommended: 3."
     entity-activation-range.animals:
     - expressions:
       - int(spigot["world-settings"]["default"]["entity-activation-range"]["animals"]) >= 32
       prefix: "❌ "
-      value: "Decrease this in spigot.yml.\nRecommended: 6."
+      value: "Decrease this in [spigot.yml](http://bit.ly/spiconf).\nRecommended: 6."
     entity-activation-range.monsters:
     - expressions:
       - int(spigot["world-settings"]["default"]["entity-activation-range"]["monsters"]) >= 32
       prefix: "❌ "
-      value: "Decrease this in spigot.yml.\nRecommended: 16."
+      value: "Decrease this in [spigot.yml](http://bit.ly/spiconf).\nRecommended: 16."
     entity-activation-range.misc:
     - expressions:
       - int(spigot["world-settings"]["default"]["entity-activation-range"]["misc"]) >= 16
       prefix: "❌ "
-      value: "Decrease this in spigot.yml.\nRecommended: 4."
+      value: "Decrease this in [spigot.yml](http://bit.ly/spiconf).\nRecommended: 4."
     entity-activation-range.water:
     - expressions:
       - int(spigot["world-settings"]["default"]["entity-activation-range"]["water"]) >= 16
       prefix: "❌ "
-      value: "Decrease this in spigot.yml.\nRecommended: 12."
+      value: "Decrease this in [spigot.yml](http://bit.ly/spiconf).\nRecommended: 12."
     entity-activation-range.villagers:
     - expressions:
       - int(spigot["world-settings"]["default"]["entity-activation-range"]["villagers"]) >= 32
       prefix: "❌ "
-      value: "Decrease this in spigot.yml.\nRecommended: 16."
+      value: "Decrease this in [spigot.yml](http://bit.ly/spiconf).\nRecommended: 16."
     entity-activation-range.tick-inactive-villagers:
     - expressions:
       - spigot["world-settings"]["default"]["entity-activation-range"]["tick-inactive-villagers"] == "true"
       prefix: "❌ "
-      value: "Disable this in spigot.yml."
+      value: "Disable this in [spigot.yml](http://bit.ly/spiconf)."
     nerf-spawner-mobs:
     - expressions:
       - spigot["world-settings"]["default"]["nerf-spawner-mobs"] == "false"
       prefix: "❌ "
-      value: "Enable this in spigot.yml."
+      value: "Enable this in [spigot.yml](http://bit.ly/spiconf)."
     entity-activation-range.wake-up-inactive.villagers-for:
     - expressions:
       - int(spigot["world-settings"]["default"]["entity-activation-range"]["wake-up-inactive"]["villagers-for"]) >= 100
       prefix: "❌ "
-      value: "Decrease this in spigot.yml.\nRecommended: 20."
+      value: "Decrease this in [spigot.yml](http://bit.ly/spiconf).\nRecommended: 20."
     entity-activation-range.wake-up-inactive.flying-monsters-for:
     - expressions:
       - int(spigot["world-settings"]["default"]["entity-activation-range"]["wake-up-inactive"]["flying-monsters-for"]) >= 100
       prefix: "❌ "
-      value: "Decrease this in spigot.yml.\nRecommended: 60."
+      value: "Decrease this in [spigot.yml](http://bit.ly/spiconf).\nRecommended: 60."
     entity-activation-range.wake-up-inactive.villagers-max-per-tick:
     - expressions:
       - int(spigot["world-settings"]["default"]["entity-activation-range"]["wake-up-inactive"]["villagers-max-per-tick"]) >= 4
       prefix: "❌ "
-      value: "Decrease this in spigot.yml.\nRecommended: 1."
+      value: "Decrease this in [spigot.yml](http://bit.ly/spiconf).\nRecommended: 1."
     entity-activation-range.wake-up-inactive.animals-for:
     - expressions:
-      - int(spigot["world-settings"]["default"]["entity-activation-range"]["wake-up-inactive"]["animals-for"]) >= 4
+      - int(spigot["world-settings"]["default"]["entity-activation-range"]["wake-up-inactive"]["animals-for"]) >= 100
       prefix: "❌ "
-      value: "Decrease this in spigot.yml.\nRecommended: 1."
+      value: "Decrease this in [spigot.yml](http://bit.ly/spiconf).\nRecommended: 40."
     entity-activation-range.wake-up-inactive.monsters-max-per-tick:
     - expressions:
       - int(spigot["world-settings"]["default"]["entity-activation-range"]["wake-up-inactive"]["monsters-max-per-tick"]) >= 8
       prefix: "❌ "
-      value: "Decrease this in spigot.yml.\nRecommended: 4."
+      value: "Decrease this in [spigot.yml](http://bit.ly/spiconf).\nRecommended: 4."
     entity-activation-range.wake-up-inactive.flying-monsters-max-per-tick:
     - expressions:
       - int(spigot["world-settings"]["default"]["entity-activation-range"]["wake-up-inactive"]["flying-monsters-max-per-tick"]) >= 8
       prefix: "❌ "
-      value: "Decrease this in spigot.yml.\nRecommended: 1."
+      value: "Decrease this in [spigot.yml](http://bit.ly/spiconf).\nRecommended: 1."
     entity-activation-range.wake-up-inactive.animals-max-per-tick:
     - expressions:
       - int(spigot["world-settings"]["default"]["entity-activation-range"]["wake-up-inactive"]["animals-max-per-tick"]) >= 4
       prefix: "❌ "
-      value: "Decrease this in spigot.yml.\nRecommended: 2."
+      value: "Decrease this in [spigot.yml](http://bit.ly/spiconf).\nRecommended: 2."
     entity-activation-range.wake-up-inactive.monsters-for:
     - expressions:
       - int(spigot["world-settings"]["default"]["entity-activation-range"]["wake-up-inactive"]["monsters-for"]) >= 100
       prefix: "❌ "
-      value: "Decrease this in spigot.yml.\nRecommended: 60."
+      value: "Decrease this in [spigot.yml](http://bit.ly/spiconf).\nRecommended: 60."
     arrow-despawn-rate:
     - expressions:
       - int(spigot["world-settings"]["default"]["arrow-despawn-rate"]) >= 1200
       prefix: "❌ "
-      value: "Decrease this in spigot.yml.\nRecommended: 300."
+      value: "Decrease this in [spigot.yml](http://bit.ly/spiconf).\nRecommended: 300."
     merge-radius.item:
     - expressions:
       - float(spigot["world-settings"]["default"]["merge-radius"]["item"]) <= 2.5
       prefix: "❌ "
-      value: "Increase this in spigot.yml.\nRecommended: 4.0."
+      value: "Increase this in [spigot.yml](http://bit.ly/spiconf).\nRecommended: 4.0."
     merge-radius.exp:
     - expressions:
       - float(spigot["world-settings"]["default"]["merge-radius"]["exp"]) <= 3.0
       prefix: "❌ "
-      value: "Increase this in spigot.yml.\nRecommended: 6.0."
+      value: "Increase this in [spigot.yml](http://bit.ly/spiconf).\nRecommended: 6.0."
     max-entity-collisions:
     - expressions:
-      - int(spigot["world-settings"]["default"]["merge-radius"]["exp"]) >= 8
+      - int(spigot["world-settings"]["default"]["max-entity-collisions"]) >= 8
       prefix: "❌ "
-      value: "Decrease this in spigot.yml.\nRecommended: 2."
+      value: "Decrease this in [spigot.yml](http://bit.ly/spiconf).\nRecommended: 2."
+    mob-spawn-range:
+    - expressions:
+      - spigot["world-settings"]["default"]["view-distance"] == "default"
+      - int(spigot["world-settings"]["default"]["mob-spawn-range"]) >= 8
+      - int(server_properties["view-distance"]) <= 6
+      prefix: "❌ "
+      value: "Decrease this in [spigot.yml](http://bit.ly/spiconf).\nRecommended: {int(server_properties[\"view-distance\"]) - 1}."
+    - expressions:
+      - int(spigot["world-settings"]["default"]["mob-spawn-range"]) >= 8
+      - int(spigot["world-settings"]["default"]["view-distance"]) <= 6
+      prefix: "❌ "
+      value: "Decrease this in [spigot.yml](http://bit.ly/spiconf).\nRecommended: {int(spigot[\"world-settings\"][\"default\"][\"view-distance\"]) - 1}."
   paper:
     max-auto-save-chunks-per-tick:
     - expressions:
       - int(paper["world-settings"]["default"]["max-auto-save-chunks-per-tick"]) >= 24
       prefix: "❌ "
-      value: "Decrease this in paper.yml.\nRecommended: 6."
+      value: "Decrease this in [paper.yml](http://bit.ly/paperconf).\nRecommended: 6."
     optimize-explosions:
     - expressions:
       - paper["world-settings"]["default"]["optimize-explosions"] == "false"
       prefix: "❌ "
-      value: "Enable this in paper.yml."
+      value: "Enable this in [paper.yml](http://bit.ly/paperconf)."
     mob-spawner-tick-rate:
     - expressions:
       - int(paper["world-settings"]["default"]["mob-spawner-tick-rate"]) == 1
       prefix: "❌ "
-      value: "Increase this in paper.yml.\nRecommended: 2."
+      value: "Increase this in [paper.yml](http://bit.ly/paperconf).\nRecommended: 2."
     game-mechanics.disable-chest-cat-detection:
     - expressions:
       - paper["world-settings"]["default"]["game-mechanics"]["disable-chest-cat-detection"] == "false"
       prefix: "❌ "
-      value: "Enable this in paper.yml"
+      value: "Enable this in [paper.yml](http://bit.ly/paperconf)"
     container-update-tick-rate:
     - expressions:
-      - paper["world-settings"]["default"]["game-mechanics"]["container-update-tick-rate"] == "false"
+      - int(paper["world-settings"]["default"]["container-update-tick-rate"]) == 1
       prefix: "❌ "
-      value: "Increase this in paper.yml.\nRecommended: 3."
+      value: "Increase this in [paper.yml](http://bit.ly/paperconf).\nRecommended: 3."
     grass-spread-tick-rate:
     - expressions:
-      - int(paper["world-settings"]["default"]["game-mechanics"]["grass-spread-tick-rate"]) == 1
+      - int(paper["world-settings"]["default"]["grass-spread-tick-rate"]) == 1
       prefix: "❌ "
-      value: "Increase this in paper.yml.\nRecommended: 4."
+      value: "Increase this in [paper.yml](http://bit.ly/paperconf).\nRecommended: 4."
     despawn-ranges.soft:
     - expressions:
       - int(paper["world-settings"]["default"]["despawn-ranges"]["soft"]) >= 32
       prefix: "❌ "
-      value: "Decrease this in paper.yml.\nRecommended: 28."
+      value: "Decrease this in [paper.yml](http://bit.ly/paperconf).\nRecommended: 28."
     despawn-ranges.hard:
     - expressions:
-      - int(paper["world-settings"]["default"]["despawn-ranges"]["hard"]) >= 32
+      - int(paper["world-settings"]["default"]["despawn-ranges"]["hard"]) >= 128
       prefix: "❌ "
-      value: "Decrease this in paper.yml.\nRecommended: 48."
+      value: "Decrease this in [paper.yml](http://bit.ly/paperconf).\nRecommended: 48."
     hopper.disable-move-event:
     - expressions:
       - paper["world-settings"]["default"]["hopper"]["disable-move-event"] == "false"
       prefix: "❌ "
-      value: "Enable this in paper.yml"
+      value: "Enable this in [paper.yml](http://bit.ly/paperconf)"
     non-player-arrow-despawn-rate:
     - expressions:
       - int(paper["world-settings"]["default"]["non-player-arrow-despawn-rate"]) == -1
       prefix: "❌ "
-      value: "Set a value in paper.yml.\nRecommended: 60"
+      value: "Set a value in [paper.yml](http://bit.ly/paperconf).\nRecommended: 60"
     creative-arrow-despawn-rate:
     - expressions:
       - int(paper["world-settings"]["default"]["creative-arrow-despawn-rate"]) == -1
       prefix: "❌ "
-      value: "Set a value in paper.yml.\nRecommended: 60"
+      value: "Set a value in [paper.yml](http://bit.ly/paperconf).\nRecommended: 60"
     non-player-arrow-despawn-rate:
     - expressions:
       - paper["world-settings"]["default"]["prevent-moving-into-unloaded-chunks"] == "false"
       prefix: "❌ "
-      value: "Enable this in paper.yml."
+      value: "Enable this in [paper.yml](http://bit.ly/paperconf)."
     use-faster-eigencraft-redstone:
     - expressions:
       - paper["world-settings"]["default"]["use-faster-eigencraft-redstone"] == "false"
       prefix: "❌ "
-      value: "Enable this in paper.yml."
+      value: "Enable this in [paper.yml](http://bit.ly/paperconf)."
     fix-climbing-bypassing-cramming-rule:
     - expressions:
       - paper["world-settings"]["default"]["fix-climbing-bypassing-cramming-rule"] == "false"
       prefix: "❌ "
-      value: "Enable this in paper.yml."
+      value: "Enable this in [paper.yml](http://bit.ly/paperconf)."
     armor-stands-do-collision-entity-lookups:
     - expressions:
       - paper["world-settings"]["default"]["armor-stands-do-collision-entity-lookups"] == "true"
       prefix: "❌ "
-      value: "Disable this in paper.yml."
+      value: "Disable this in [paper.yml](http://bit.ly/paperconf)."
     armor-stands-tick:
     - expressions:
       - paper["world-settings"]["default"]["armor-stands-tick"] == "true"
@@ -387,65 +427,88 @@ config:
       - '"BlockBalls" not in plugins'
       - '"ArmorStandTools" not in plugins'
       prefix: "❌ "
-      value: "Disable this in paper.yml."
+      value: "Disable this in [paper.yml](http://bit.ly/paperconf)."
     per-player-mob-spawns:
     - expressions:
       - paper["world-settings"]["default"]["per-player-mob-spawns"] == "false"
       prefix: "❌ "
-      value: "Enable this in paper.yml."
+      value: "Enable this in [paper.yml](http://bit.ly/paperconf)."
     alt-item-despawn-rate.enabled:
     - expressions:
       - paper["world-settings"]["default"]["alt-item-despawn-rate"]["enabled"] == "false"
       prefix: "❌ "
-      value: "Enable this in paper.yml."
+      value: "Enable this in [paper.yml](http://bit.ly/paperconf)."
     enable-treasure-maps:
     - expressions:
       - paper["world-settings"]["default"]["enable-treasure-maps"] == "true"
       prefix: "❌ "
-      value: "Disable this in paper.yml. Why? Generating treasure maps is extremely expensive and can hang a server if the structure it's trying to locate is really far away."
+      value: "Disable this in [paper.yml](http://bit.ly/paperconf). Why? Generating treasure maps is extremely expensive and can hang a server if the structure it's trying to locate is really far away."
     projectile-load-save-per-chunk-limit:
     - expressions:
       - int(paper["world-settings"]["default"]["projectile-load-save-per-chunk-limit"]) == -1
       prefix: "❌ "
-      value: "Set a value in paper.yml. Recommended: 8."
+      value: "Set a value in [paper.yml](http://bit.ly/paperconf). Recommended: 8."
+    no-tick-view-distance:
+    - expressions:
+      - int(paper["world-settings"]["default"]["viewdistances"]["no-tick-view-distance"]) == -1
+      - spigot["world-settings"]["default"]["view-distance"] == "default"
+      - int(server_properties["view-distance"]) >= 4
+      prefix: "❌ "
+      value: Set a value in [paper.yml](http://bit.ly/paperconf).\nRecommended {server_properties["view-distance"]}. Reduce view-distance in server.properties to 3.
+    - expressions:
+      - int(paper["world-settings"]["default"]["viewdistances"]["no-tick-view-distance"]) == -1
+      - int(spigot["world-settings"]["default"]["view-distance"]) >= 4
+      prefix: "❌ "
+      value: Set a value in [paper.yml](http://bit.ly/paperconf).\nRecommended {spigot["world-settings"]["default"]["view-distance"]}. Reduce view-distance in server.properties to 3.
   purpur:
+    settings.use-alternate-keepalive:
+    - expressions:
+      - purpur["settings"]["use-alternate-keepalive"] == "false"
+      - '"TCPShield" not in plugins'
+      prefix: "❌ "
+      value: "Enable this in [purpur.yml](http://bit.ly/purpurc)."
+    - expressions:
+      - purpur["settings"]["use-alternate-keepalive"] == "true"
+      - '"TCPShield" in plugins'
+      prefix: "❌ "
+      value: "Disable this in [purpur.yml](http://bit.ly/purpurc). It can cause issues with TCPShield"
     settings.dont-send-useless-entity-packets:
     - expressions:
       - purpur["settings"]["dont-send-useless-entity-packets"] == "false"
       prefix: "❌ "
-      value: "Enable this in purpur.yml."
+      value: "Enable this in [purpur.yml](http://bit.ly/purpurc)."
     mobs.dolphin.disable-treasure-searching:
     - expressions:
       - purpur["world-settings"]["default"]["mobs"]["dolphin"]["disable-treasure-searching"] == "false"
       prefix: "❌ "
-      value: "Enable this in purpur.yml."
+      value: "Enable this in [purpur.yml](http://bit.ly/purpurc)."
     mobs.villager.brain-ticks:
     - expressions:
       - int(purpur["world-settings"]["default"]["mobs"]["villager"]["brain-ticks"]) == 1
       prefix: "❌ "
-      value: "Increase this in purpur.yml.\nRecommended: 4."
+      value: "Increase this in [purpur.yml](http://bit.ly/purpurc).\nRecommended: 4."
     mobs.villager.spawn-iron-golem.radius:
     - expressions:
       - int(purpur["world-settings"]["default"]["mobs"]["villager"]["spawn-iron-golem"]["radius"]) == 0
       prefix: "❌ "
-      value: "Increase this in purpur.yml.\nRecommended: 5."
+      value: "Increase this in [purpur.yml](http://bit.ly/purpurc).\nRecommended: 5."
     mobs.zombie.aggressive-towards-villager-when-lagging:
     - expressions:
       - purpur["world-settings"]["default"]["mobs"]["zombie"]["aggressive-towards-villager-when-lagging"] == "true"
       prefix: "❌ "
-      value: "Disable this in purpur.yml."
+      value: "Disable this in [purpur.yml](http://bit.ly/purpurc)."
     gameplay-mechanics.entities-can-use-portals:
     - expressions:
       - purpur["world-settings"]["default"]["gameplay-mechanics"]["entities-can-use-portals"] == "true"
       prefix: "❌ "
-      value: "Disable this in purpur.yml to prevent players from creating chunk anchors."
+      value: "Disable this in [purpur.yml](http://bit.ly/purpurc) to prevent players from creating chunk anchors."
     mobs.villager.lobotomize.enabled:
     - expressions:
       - purpur["world-settings"]["default"]["mobs"]["villager"]["lobotomize"]["enabled"] == "false"
       prefix: "❌ "
-      value: "Enable this in purpur.yml."
+      value: "Enable this in [purpur.yml](http://bit.ly/purpurc)."
     gameplay-mechanics.player.teleport-if-outside-border:
     - expressions:
       - purpur["world-settings"]["default"]["gameplay-mechanics"]["player"]["teleport-if-outside-border"] == "false"
       prefix: "❌ "
-      value: "Enable this in purpur.yml."
+      value: "Enable this in [purpur.yml](http://bit.ly/purpurc)."

--- a/cogs/timings_check.yml
+++ b/cogs/timings_check.yml
@@ -155,3 +155,297 @@ plugins:
             value: |-
                 "You probably don't need VillagerLobotomizatornator as Purpur already adds its features. "
                 "Enable villager.lobotomize.enabled in purpur.yml."
+config:
+  server.properties:
+    online-mode:
+    - expressions:
+      - not server_properties["online-mode"]
+      - spigot["settings"]["bungeecord"] == "false"
+      - paper["settings"]["velocity-support"]["online-mode"] == "false" or paper["settings"]["velocity-support"]["enabled"] == "false"
+      prefix: "❌ "
+      value: "Enable this in server.properties for security."
+  bukkit:
+    chunk-gc.period-in-ticks:
+    - expressions:
+      - int(bukkit["chunk-gc"]["period-in-ticks"]) >= 600
+      prefix: "❌ "
+      value: "Decrease this in bukkit.yml.\nRecommended: 400."
+    ticks-per.monster-spawns:
+    - expressions:
+      - int(bukkit["ticks-per"]["monster-spawns"]) == 1
+      prefix: "❌ "
+      value: "Increase this in bukkit.yml.\nRecommended: 4."
+    spawn-limits.monsters:
+    - expressions:
+      - int(bukkit["spawn-limits"]["monsters"]) >= 70
+      prefix: "❌ "
+      value: "Decrease this in bukkit.yml.\nRecommended: 15."
+    spawn-limits.water-ambient:
+    - expressions:
+      - int(bukkit["spawn-limits"]["water-ambient"]) >= 20
+      prefix: "❌ "
+      value: "Decrease this in bukkit.yml.\nRecommended: 2."
+    spawn-limits.ambient:
+    - expressions:
+      - int(bukkit["spawn-limits"]["ambient"]) >= 15
+      prefix: "❌ "
+      value: "Decrease this in bukkit.yml.\nRecommended: 1."
+    spawn-limits.animals:
+    - expressions:
+      - int(bukkit["spawn-limits"]["animals"]) >= 10
+      prefix: "❌ "
+      value: "Decrease this in bukkit.yml.\nRecommended: 3."
+    spawn-limits.water-animals:
+    - expressions:
+      - int(bukkit["spawn-limits"]["water-animals"]) >= 15
+      prefix: "❌ "
+      value: "Decrease this in bukkit.yml.\nRecommended: 2."
+  spigot:
+    view-distance:
+    - expressions:
+      - server_properties["view-distance"] >= 10
+      - spigot["world-settings"]["default"]["view-distance"] == "default"
+      prefix: "❌ "
+      value: |-
+        "Decrease this from default (10) in spigot.yml. "
+        "Recommended: 3."
+    entity-activation-range.animals:
+    - expressions:
+      - int(spigot["world-settings"]["default"]["entity-activation-range"]["animals"]) >= 32
+      prefix: "❌ "
+      value: "Decrease this in spigot.yml.\nRecommended: 6."
+    entity-activation-range.monsters:
+    - expressions:
+      - int(spigot["world-settings"]["default"]["entity-activation-range"]["monsters"]) >= 32
+      prefix: "❌ "
+      value: "Decrease this in spigot.yml.\nRecommended: 16."
+    entity-activation-range.misc:
+    - expressions:
+      - int(spigot["world-settings"]["default"]["entity-activation-range"]["misc"]) >= 16
+      prefix: "❌ "
+      value: "Decrease this in spigot.yml.\nRecommended: 4."
+    entity-activation-range.water:
+    - expressions:
+      - int(spigot["world-settings"]["default"]["entity-activation-range"]["water"]) >= 16
+      prefix: "❌ "
+      value: "Decrease this in spigot.yml.\nRecommended: 12."
+    entity-activation-range.villagers:
+    - expressions:
+      - int(spigot["world-settings"]["default"]["entity-activation-range"]["villagers"]) >= 32
+      prefix: "❌ "
+      value: "Decrease this in spigot.yml.\nRecommended: 16."
+    entity-activation-range.tick-inactive-villagers:
+    - expressions:
+      - spigot["world-settings"]["default"]["entity-activation-range"]["tick-inactive-villagers"] == "true"
+      prefix: "❌ "
+      value: "Disable this in spigot.yml."
+    nerf-spawner-mobs:
+    - expressions:
+      - spigot["world-settings"]["default"]["nerf-spawner-mobs"] == "false"
+      prefix: "❌ "
+      value: "Enable this in spigot.yml."
+    entity-activation-range.wake-up-inactive.villagers-for:
+    - expressions:
+      - int(spigot["world-settings"]["default"]["entity-activation-range"]["wake-up-inactive"]["villagers-for"]) >= 100
+      prefix: "❌ "
+      value: "Decrease this in spigot.yml.\nRecommended: 20."
+    entity-activation-range.wake-up-inactive.flying-monsters-for:
+    - expressions:
+      - int(spigot["world-settings"]["default"]["entity-activation-range"]["wake-up-inactive"]["flying-monsters-for"]) >= 100
+      prefix: "❌ "
+      value: "Decrease this in spigot.yml.\nRecommended: 60."
+    entity-activation-range.wake-up-inactive.villagers-max-per-tick:
+    - expressions:
+      - int(spigot["world-settings"]["default"]["entity-activation-range"]["wake-up-inactive"]["villagers-max-per-tick"]) >= 4
+      prefix: "❌ "
+      value: "Decrease this in spigot.yml.\nRecommended: 1."
+    entity-activation-range.wake-up-inactive.animals-for:
+    - expressions:
+      - int(spigot["world-settings"]["default"]["entity-activation-range"]["wake-up-inactive"]["animals-for"]) >= 4
+      prefix: "❌ "
+      value: "Decrease this in spigot.yml.\nRecommended: 1."
+    entity-activation-range.wake-up-inactive.monsters-max-per-tick:
+    - expressions:
+      - int(spigot["world-settings"]["default"]["entity-activation-range"]["wake-up-inactive"]["monsters-max-per-tick"]) >= 8
+      prefix: "❌ "
+      value: "Decrease this in spigot.yml.\nRecommended: 4."
+    entity-activation-range.wake-up-inactive.flying-monsters-max-per-tick:
+    - expressions:
+      - int(spigot["world-settings"]["default"]["entity-activation-range"]["wake-up-inactive"]["flying-monsters-max-per-tick"]) >= 8
+      prefix: "❌ "
+      value: "Decrease this in spigot.yml.\nRecommended: 1."
+    entity-activation-range.wake-up-inactive.animals-max-per-tick:
+    - expressions:
+      - int(spigot["world-settings"]["default"]["entity-activation-range"]["wake-up-inactive"]["animals-max-per-tick"]) >= 4
+      prefix: "❌ "
+      value: "Decrease this in spigot.yml.\nRecommended: 2."
+    entity-activation-range.wake-up-inactive.monsters-for:
+    - expressions:
+      - int(spigot["world-settings"]["default"]["entity-activation-range"]["wake-up-inactive"]["monsters-for"]) >= 100
+      prefix: "❌ "
+      value: "Decrease this in spigot.yml.\nRecommended: 60."
+    arrow-despawn-rate:
+    - expressions:
+      - int(spigot["world-settings"]["default"]["arrow-despawn-rate"]) >= 1200
+      prefix: "❌ "
+      value: "Decrease this in spigot.yml.\nRecommended: 300."
+    merge-radius.item:
+    - expressions:
+      - float(spigot["world-settings"]["default"]["merge-radius"]["item"]) <= 2.5
+      prefix: "❌ "
+      value: "Increase this in spigot.yml.\nRecommended: 4.0."
+    merge-radius.exp:
+    - expressions:
+      - float(spigot["world-settings"]["default"]["merge-radius"]["exp"]) <= 3.0
+      prefix: "❌ "
+      value: "Increase this in spigot.yml.\nRecommended: 6.0."
+    max-entity-collisions:
+    - expressions:
+      - int(spigot["world-settings"]["default"]["merge-radius"]["exp"]) >= 8
+      prefix: "❌ "
+      value: "Decrease this in spigot.yml.\nRecommended: 2."
+  paper:
+    max-auto-save-chunks-per-tick:
+    - expressions:
+      - int(paper["world-settings"]["default"]["max-auto-save-chunks-per-tick"]) >= 24
+      prefix: "❌ "
+      value: "Decrease this in paper.yml.\nRecommended: 6."
+    optimize-explosions:
+    - expressions:
+      - paper["world-settings"]["default"]["optimize-explosions"] == "false"
+      prefix: "❌ "
+      value: "Enable this in paper.yml."
+    mob-spawner-tick-rate:
+    - expressions:
+      - int(paper["world-settings"]["default"]["mob-spawner-tick-rate"]) == 1
+      prefix: "❌ "
+      value: "Increase this in paper.yml.\nRecommended: 2."
+    game-mechanics.disable-chest-cat-detection:
+    - expressions:
+      - paper["world-settings"]["default"]["game-mechanics"]["disable-chest-cat-detection"] == "false"
+      prefix: "❌ "
+      value: "Enable this in paper.yml"
+    container-update-tick-rate:
+    - expressions:
+      - paper["world-settings"]["default"]["game-mechanics"]["container-update-tick-rate"] == "false"
+      prefix: "❌ "
+      value: "Increase this in paper.yml.\nRecommended: 3."
+    grass-spread-tick-rate:
+    - expressions:
+      - int(paper["world-settings"]["default"]["game-mechanics"]["grass-spread-tick-rate"]) == 1
+      prefix: "❌ "
+      value: "Increase this in paper.yml.\nRecommended: 4."
+    despawn-ranges.soft:
+    - expressions:
+      - int(paper["world-settings"]["default"]["despawn-ranges"]["soft"]) >= 32
+      prefix: "❌ "
+      value: "Decrease this in paper.yml.\nRecommended: 28."
+    despawn-ranges.hard:
+    - expressions:
+      - int(paper["world-settings"]["default"]["despawn-ranges"]["hard"]) >= 32
+      prefix: "❌ "
+      value: "Decrease this in paper.yml.\nRecommended: 48."
+    hopper.disable-move-event:
+    - expressions:
+      - paper["world-settings"]["default"]["hopper"]["disable-move-event"] == "false"
+      prefix: "❌ "
+      value: "Enable this in paper.yml"
+    non-player-arrow-despawn-rate:
+    - expressions:
+      - int(paper["world-settings"]["default"]["non-player-arrow-despawn-rate"]) == -1
+      prefix: "❌ "
+      value: "Set a value in paper.yml.\nRecommended: 60"
+    creative-arrow-despawn-rate:
+    - expressions:
+      - int(paper["world-settings"]["default"]["creative-arrow-despawn-rate"]) == -1
+      prefix: "❌ "
+      value: "Set a value in paper.yml.\nRecommended: 60"
+    non-player-arrow-despawn-rate:
+    - expressions:
+      - paper["world-settings"]["default"]["prevent-moving-into-unloaded-chunks"] == "false"
+      prefix: "❌ "
+      value: "Enable this in paper.yml."
+    use-faster-eigencraft-redstone:
+    - expressions:
+      - paper["world-settings"]["default"]["use-faster-eigencraft-redstone"] == "false"
+      prefix: "❌ "
+      value: "Enable this in paper.yml."
+    fix-climbing-bypassing-cramming-rule:
+    - expressions:
+      - paper["world-settings"]["default"]["fix-climbing-bypassing-cramming-rule"] == "false"
+      prefix: "❌ "
+      value: "Enable this in paper.yml."
+    armor-stands-do-collision-entity-lookups:
+    - expressions:
+      - paper["world-settings"]["default"]["armor-stands-do-collision-entity-lookups"] == "true"
+      prefix: "❌ "
+      value: "Disable this in paper.yml."
+    armor-stands-tick:
+    - expressions:
+      - paper["world-settings"]["default"]["armor-stands-tick"] == "true"
+      - '"PetBlocks" not in plugins'
+      - '"BlockBalls" not in plugins'
+      - '"ArmorStandTools" not in plugins'
+      prefix: "❌ "
+      value: "Disable this in paper.yml."
+    per-player-mob-spawns:
+    - expressions:
+      - paper["world-settings"]["default"]["per-player-mob-spawns"] == "false"
+      prefix: "❌ "
+      value: "Enable this in paper.yml."
+    alt-item-despawn-rate.enabled:
+    - expressions:
+      - paper["world-settings"]["default"]["alt-item-despawn-rate"]["enabled"] == "false"
+      prefix: "❌ "
+      value: "Enable this in paper.yml."
+    enable-treasure-maps:
+    - expressions:
+      - paper["world-settings"]["default"]["enable-treasure-maps"] == "true"
+      prefix: "❌ "
+      value: "Disable this in paper.yml. Why? Generating treasure maps is extremely expensive and can hang a server if the structure it's trying to locate is really far away."
+    projectile-load-save-per-chunk-limit:
+    - expressions:
+      - int(paper["world-settings"]["default"]["projectile-load-save-per-chunk-limit"]) == -1
+      prefix: "❌ "
+      value: "Set a value in paper.yml. Recommended: 8."
+  purpur:
+    settings.dont-send-useless-entity-packets:
+    - expressions:
+      - purpur["settings"]["dont-send-useless-entity-packets"] == "false"
+      prefix: "❌ "
+      value: "Enable this in purpur.yml."
+    mobs.dolphin.disable-treasure-searching:
+    - expressions:
+      - purpur["world-settings"]["default"]["mobs"]["dolphin"]["disable-treasure-searching"] == "false"
+      prefix: "❌ "
+      value: "Enable this in purpur.yml."
+    mobs.villager.brain-ticks:
+    - expressions:
+      - int(purpur["world-settings"]["default"]["mobs"]["villager"]["brain-ticks"]) == 1
+      prefix: "❌ "
+      value: "Increase this in purpur.yml.\nRecommended: 4."
+    mobs.villager.spawn-iron-golem.radius:
+    - expressions:
+      - int(purpur["world-settings"]["default"]["mobs"]["villager"]["spawn-iron-golem"]["radius"]) == 0
+      prefix: "❌ "
+      value: "Increase this in purpur.yml.\nRecommended: 5."
+    mobs.zombie.aggressive-towards-villager-when-lagging:
+    - expressions:
+      - purpur["world-settings"]["default"]["mobs"]["zombie"]["aggressive-towards-villager-when-lagging"] == "true"
+      prefix: "❌ "
+      value: "Disable this in purpur.yml."
+    gameplay-mechanics.entities-can-use-portals:
+    - expressions:
+      - purpur["world-settings"]["default"]["gameplay-mechanics"]["entities-can-use-portals"] == "true"
+      prefix: "❌ "
+      value: "Disable this in purpur.yml to prevent players from creating chunk anchors."
+    mobs.villager.lobotomize.enabled:
+    - expressions:
+      - purpur["world-settings"]["default"]["mobs"]["villager"]["lobotomize"]["enabled"] == "false"
+      prefix: "❌ "
+      value: "Enable this in purpur.yml."
+    gameplay-mechanics.player.teleport-if-outside-border:
+    - expressions:
+      - purpur["world-settings"]["default"]["gameplay-mechanics"]["player"]["teleport-if-outside-border"] == "false"
+      prefix: "❌ "
+      value: "Enable this in purpur.yml."

--- a/cogs/timings_check.yml
+++ b/cogs/timings_check.yml
@@ -448,18 +448,6 @@ config:
       - int(paper["world-settings"]["default"]["projectile-load-save-per-chunk-limit"]) == -1
       prefix: "❌ "
       value: "Set a value in [paper.yml](http://bit.ly/paperconf). Recommended: 8."
-    no-tick-view-distance:
-    - expressions:
-      - int(paper["world-settings"]["default"]["viewdistances"]["no-tick-view-distance"]) == -1
-      - spigot["world-settings"]["default"]["view-distance"] == "default"
-      - int(server_properties["view-distance"]) >= 4
-      prefix: "❌ "
-      value: Set a value in [paper.yml](http://bit.ly/paperconf).\nRecommended {server_properties["view-distance"]}. Reduce view-distance in server.properties to 3.
-    - expressions:
-      - int(paper["world-settings"]["default"]["viewdistances"]["no-tick-view-distance"]) == -1
-      - int(spigot["world-settings"]["default"]["view-distance"]) >= 4
-      prefix: "❌ "
-      value: Set a value in [paper.yml](http://bit.ly/paperconf).\nRecommended {spigot["world-settings"]["default"]["view-distance"]}. Reduce view-distance in server.properties to 3.
   purpur:
     settings.use-alternate-keepalive:
     - expressions:

--- a/cogs/timings_check.yml
+++ b/cogs/timings_check.yml
@@ -1,0 +1,144 @@
+---
+plugins:
+    paper:
+        ClearLag:
+            prefix: "⚠ "
+            value: |-
+                "Plugins that claim to remove lag actually cause more lag. "
+                "Remove ClearLag."
+        LagAssist:
+            prefix: "⚠ "
+            value: |-
+                "LagAssist should only be used for analytics and preventative measures."
+                "All other features of the plugin should be disabled."
+        NoChunkLag:
+            prefix: "⚠ "
+            value: |-
+                "Plugins that claim to remove lag actually cause more lag. "
+                "Remove NoChunkLag."
+        ServerBooster:
+            prefix: "⚠ "
+            value: |-
+                "Plugins that claim to remove lag actually cause more lag. "
+                "Remove ServerBooster."
+        MobLimiter:
+            prefix: "⚠ "
+            value: |-
+                "You probably don't need MobLimiter as Bukkit already has its features. "
+                "Remove MobLimiter."
+        BookLimiter:
+            prefix: "⚠ "
+            value: |-
+                "You probably don't need BookLimiter as Paper already has its features. "
+                "Remove BookLimiter."
+        LimitPillagers:
+            prefix: "⚠ "
+            value: |-
+                "You probably don't need LimitPillagers as Paper already adds its features. "
+                "Remove LimitPillagers."
+        VillagerOptimiser:
+            prefix: "⚠ "
+            value: |-
+                "You probably don't need VillagerOptimiser as Paper already adds its features. "
+                "See entity-activation-range in spigot.yml."
+        StackMob:
+            prefix: "⚠ "
+            value: |-
+                "Stacking plugins actually cause more lag. "
+                "Remove StackMob."
+        Stacker:
+            prefix: "⚠ "
+            value: |-
+                "Stacking plugins actually cause more lag. "
+                "Remove Stacker."
+        MobStacker:
+            prefix: "⚠ "
+            value: |-
+                "Stacking plugins actually cause more lag. "
+                "Remove MobStacker."
+        WildStacker:
+            prefix: "⚠ "
+            value: |-
+                "Stacking plugins actually cause more lag. "
+                "Remove WildStacker."
+        SuggestionBlocker:
+            prefix: "⚠ "
+            value: |-
+                "You probably don't need SuggestionBlocker as Spigot already adds its features. "
+                "Set tab-complete to -1 in spigot.yml."
+        FastAsyncWorldEdit:
+            prefix: "⚠ "
+            value: |-
+                "FAWE can corrupt your world. "
+                "Consider replacing FAWE with [Worldedit](https://enginehub.org/worldedit/#downloads)."
+        CMI:
+            prefix: "⚠ "
+            value: |-
+                "CMI is a buggy plugin. "
+                "Consider replacing CMI with [EssentialsX](https://essentialsx.net/downloads.html)."
+        Spartan:
+            prefix: "⚠ "
+            value: |-
+                "Spartan is a laggy anticheat. "
+                "Consider replacing it with [Matrix](https://matrix.rip/), [NCP](https://ci.codemc.io/job/Updated-NoCheatPlus/job/Updated-NoCheatPlus/), or [AAC](https://www.spigotmc.org/resources/aac-advanced-anti-cheat-hack-kill-aura-blocker.6442/)."
+        IllegalStack:
+            prefix: "⚠ "
+            value: |-
+                "You probably don't need IllegalStack as Paper already has its features. "
+                "Remove IllegalStack."
+        ExploitFixer:
+            prefix: "⚠ "
+            value: |-
+                "You probably don't need ExploitFixer as Paper already has its features. "
+                "Remove ExploitFixer."
+        EntityTrackerFixer:
+            prefix: "⚠ "
+            value: |-
+                "You probably don't need EntityTrackerFixer as Paper already has its features. "
+                "Remove EntityTrackerFixer."
+        Orebfuscator:
+            prefix: "⚠ "
+            value: |-
+                "You probably don't need Orebfuscator as Paper already has its features. "
+                "Remove Orebfuscator."
+        ImageOnMap:
+            prefix: "⚠ "
+            value: |-
+                "This plugin has a [memory leak](https://github.com/zDevelopers/ImageOnMap/issues/104). If it is not essential, you should remove it. "
+                "Consider replacing it with [an alternative](https://www.spigotmc.org/resources/drmap.87368/)."
+        CrazyActions:
+            prefix: "⚠ "
+            value: |-
+                "CrazyAuctions is a laggy plugin, even according to the developer. "
+                "Consider replacing it with [AuctionHouse](https://www.spigotmc.org/resources/auctionhouse.61836/)."
+        GroupManager:
+            prefix: "⚠ "
+            value: |-
+                "GroupManager is an outdated permission plugin. "
+                "Consider replacing it with [LuckPerms](https://ci.lucko.me/job/LuckPerms/1243/artifact/bukkit/build/libs/LuckPerms-Bukkit-5.2.77.jar)."
+        PermissionsEx:
+            prefix: "⚠ "
+            value: |-
+                "PermissionsEx is an outdated permission plugin. "
+                "Consider replacing it with [LuckPerms](https://ci.lucko.me/job/LuckPerms/1243/artifact/bukkit/build/libs/LuckPerms-Bukkit-5.2.77.jar)."
+        bPermissions:
+            prefix: "⚠ "
+            value: |-
+                "bPermissions is an outdated permission plugin. "
+                "Consider replacing it with [LuckPerms](https://ci.lucko.me/job/LuckPerms/1243/artifact/bukkit/build/libs/LuckPerms-Bukkit-5.2.77.jar)."
+    purpur:
+        SilkSpawners:
+            prefix: "⚠ "
+            value: |-
+                "You probably don't need SilkSpawners as Purpur already has its features. "
+                "Remove SilkSpawners."
+        MineableSpawners:
+            prefix: "⚠ "
+            value: |-
+                "You probably don't need MineableSpawners as Purpur already has its features. "
+                "Remove MineableSpawners."
+        VillagerLobotomizatornator:
+            prefix: "⚠ "
+            value: |-
+                "You probably don't need VillagerLobotomizatornator as Purpur already adds its features. "
+                "Enable villager.lobotomize.enabled in purpur.yml."

--- a/cogs/timings_check.yml
+++ b/cogs/timings_check.yml
@@ -1,4 +1,17 @@
 ---
+version: "1.16.4"
+servers:
+- name: "yatopia"
+  prefix: "❌ "
+  value: |-
+    "Yatopia is prone to bugs."
+    "Consider using [Purpur](https://ci.pl3x.net/job/Purpur/)."
+- name: "paper"
+  prefix: "||❌ "
+  suffix: "||"
+  value: |-
+    "||Purpur has more optimizations but is generally less supported. "
+    "Consider using [Purpur](https://ci.pl3x.net/job/Purpur/).||"
 plugins:
     paper:
         ClearLag:


### PR DESCRIPTION
This PR cleans up the code in timings.py and migrates most of the timings checks into a yaml file. The goal is to make it easier to set up analysis for timings, while also keeping the code clean. Still have a few options to add to the yaml file, but I felt it was at a good point to PR.

`version` determines what minecraft version to check to make sure the timings report is on the latest version of minecraft.
`servers` checks what server is being used (through the server jar version) from top to bottom. In the current yml file, it checks to see if the server jar is yatopia. If the server jar is not yatopia, then it iterates and checks if the server jar is paper, etc.

```yml
servers:
- name: "yatopia"
  prefix: "❌ "
  value: |-
    Yatopia is prone to bugs.
    Consider using [Purpur](https://ci.pl3x.net/job/Purpur/).
- name: "paper" # the name of the server jar
  prefix: "||❌ " # the prefix to use before the field name
  suffix: "||" # the suffix to use after the field name
  value: |- # the value which is used as the field value
    ||Purpur has more optimizations but is generally less supported. 
    Consider using [Purpur](https://ci.pl3x.net/job/Purpur/).||
```

`plugins` is where all the plugin checks are stored. plugins are nested based on the server jar ( this is checked through the config file). Using `expressions` you can have different fields pop up depending on different values

```yml
plugins:
  paper: # checks for the `paper.yml` config to see if the following plugins should be added
    ClearLag: # name of the plugin (used in field name) aka a dictionary
      prefix: "⚠ " # prefix to use for the field name (suffix option can be added)
      value: |- # field value 
        Plugins that claim to remove lag actually cause more lag. 
        Remove ClearLag.
    PhantomSMP: # a list of expressions
    - expressions: # inside the expressions option there are a list of expressions. Each expression is checked from top to bottom, compared using AND
      - paper["world-settings"]["default"]["phantoms-only-attack-insomniacs"] == "false" # basically an if statement in the form of a string
      prefix: "⚠ "
      value: |-
        You probably don't need PhantomSMP as Paper already has its features.
        Remove PhantomSMP.
    - expressions: # if the earlier expression fails, then the next one will be checked
      - paper["world-settings"]["default"]["phantoms-only-attack-insomniacs"] == "true"
      prefix: "⚠ "
      value: |-
        You probably don't need PhantomSMP as Paper already has its features.
        Enable phantoms-only-attack-insomniacs in [paper.yml](http://bit.ly/paperconf).
  purpur:
    SilkSpawners:
      prefix: "⚠ "
      value: |-
        You probably don't need SilkSpawners as Purpur already has its features. 
        Remove SilkSpawners.
```

`config` is where all the config checks are stored. the options are nested based on what config they come from, but they don't necessarily need to be from that config. They follow the same concept and logic as the `plugins` option.

```yml
config:
  server.properties: # the config file the option is based on (options don't rely on this, this is mostly just for organizational purposes)
    online-mode: # the option name
    - expressions: # inside the expressions option there are a list of expressions. Each expression is checked from top to bottom, compared using AND
      - not server_properties["online-mode"] # if online-mode in server_properties is false, AND
      - spigot["settings"]["bungeecord"] == "false" # bungeecord is false, AND
      - paper["settings"]["velocity-support"]["online-mode"] == "false" or paper["settings"]["velocity-support"]["enabled"] == "false" # velocity-support.online-mode is false OR velocity-support.enabled is false THEN
      prefix: "❌ " # use this prefix
      value: "Enable this in [server.properties](http://bit.ly/servprop) for security."  #use this value
    network-compression-threshold:
    - expressions: # if at least one of these expressions fails, try the next pair of expressions
      - int(server_properties["network-compression-threshold"]) <= 256
      - spigot["settings"]["bungeecord"] == "false"
      prefix: "❌ "
      value: "Increase this in [server.properties](http://bit.ly/servprop). Recommended: 512."
    - expressions: # if all these expressions are true
      - int(server_properties["network-compression-threshold"]) != -1
      - spigot["settings"]["bungeecord"] == "true"
      prefix: "❌ " # use this prefix
      value: "Set this to -1 in [server.properties](http://bit.ly/servprop) for a bungee server like yours." # and use this value
```