### PR TITLE
Update timings_check.yml

### DIFF
--- a/cogs/timings_check.yml
+++ b/cogs/timings_check.yml
@@ -15,7 +15,7 @@ servers:
 - name: "Paper"
   prefix: "❌"
   value: |-
-    [Tuinity](https://ci.codemc.io/job/Spottedleaf/job/Tuinity/), [Purpur](https://ci.pl3x.net/job/Purpur/), and [Airplane](https://ci.tivy.ca/) have more optimizations with similar stability levels. Consider using one of them.
+    [Tuinity](https://ci.codemc.io/job/Spottedleaf/job/Tuinity/) and [Purpur](https://ci.pl3x.net/job/Purpur/) have more optimizations with similar stability levels. Consider using one of them.
 plugins:
   paper:
     ClearLag:


### PR DESCRIPTION
Purpur dropped Airplane's patches for a reason:

"After much internal deliberation we have come to the conclusion that it is in the best interest of Purpur and it's users that we drop Airplane's set of patches from our software.

Airplane doesn't give us nearly as much performance as we originally thought it would as it's just a small set of micro optimizations, most of which don't really give any noticeable gains at all outside of extreme circumstances. The few features that do actually change the game have done so in unexpected and unwanted ways for the majority of our users, the most notable one being DEAR.

Between these technical concerns, the voices of our users that have had problems or confirmed airplane hasn't helped them at all, and the negativity we continue to receive from the Airplane community and team in general, the decision to remove the patches was a rather simple one to make.

Fear not! Purpur is still based on Tuinity where majority of the performance gains over Paper come from. And don't forget Purpur still has its own performance oriented patches on top of that for that extra zing!

We look forward with anticipation to what the future brings us as we approach 1.17 and hope to continue giving you the best possible performance and experience running your Minecraft servers ^_^"